### PR TITLE
Remove comment about colorisation information

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1781,8 +1781,6 @@ layoutWadlerLeijen
 -- fast. The resulting output contains fewer characters than a prettyprinted
 -- version and can be used for output that is read by other programs.
 --
--- This layout function does not add any colorisation information.
---
 -- >>> let doc = hang 4 (vsep ["lorem", "ipsum", hang 4 (vsep ["dolor", "sit"])])
 -- >>> doc
 -- lorem


### PR DESCRIPTION
I believe that this comment was a hold-over from the original forked library that had built-in colorization.