### PR TITLE
Add 'Pretty (Doc Void)' instance

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -196,6 +197,11 @@ class Pretty a where
     prettyList = list . map pretty
 
     {-# MINIMAL pretty #-}
+
+-- | >>> pretty (pretty [1,2,3] :: Doc Void)
+-- [1, 2, 3]
+instance Pretty (Doc Void) where
+    pretty = fmap absurd
 
 -- | >>> pretty [1,2,3]
 -- [1, 2, 3]


### PR DESCRIPTION
It's pretty useful to have `Pretty` instance for `Doc` so that parts of a complex structure can be printed independently and/or with different styles. Due to presence of annotations, adding more general instance
is problematic. However, this limited instance seems to be a good trade-off.

Addresses #30.