### PR TITLE
Invert impl(ghc < ver) into !impl(ghc >= ver)

### DIFF
--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -41,7 +41,7 @@ library
 
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
-    if impl(ghc < 8.0)
+    if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.1
 
 test-suite doctest

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -62,9 +62,9 @@ library
 
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
-    if impl(ghc < 8.0)
+    if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.1
-    if impl(ghc < 7.10)
+    if !impl(ghc >= 7.10)
         build-depends: void
 
 
@@ -124,7 +124,7 @@ test-suite testsuite
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
     default-language: Haskell2010
 
-    if impl(ghc < 8.0)
+    if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.6
 
 


### PR DESCRIPTION
See `impl` note in
http://cabal.readthedocs.io/en/latest/developing-packages.html?highlight=impl#conditions
for explanation.

> As a result, !impl(ghc >= x.y.z) is not entirely equivalent to
> impl(ghc < x.y.z). The test !impl(ghc >= x.y.z) checks that:
>
> * The current compiler is not GHC, or
>
> * The version of GHC is earlier than version x.y.z.