### PR TITLE
Include changelog of prettyprinter in extra-source-files

### DIFF
--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -7,6 +7,7 @@ description:         See README.md
 license:             BSD2
 license-file:        LICENSE.md
 extra-source-files:  README.md
+                   , CHANGELOG.md
                    , misc/version-compatibility-macros.h
 author:              Phil Wadler, Daan Leijen, Max Bolingbroke, Edward Kmett, David Luposchainsky
 maintainer:          David Luposchainsky <dluposchainsky at google>


### PR DESCRIPTION
This will include it in the sdist tarball which means it shows up on Hackage. The other packages in this repository either already do this (in the case of `prettyprinter-ansi-terminal`) or don’t have changelog files (all other packages).