### PR TITLE
Fix .cabal file

### DIFF
--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -58,7 +58,6 @@ library
         , CPP
         , LambdaCase
         , OverloadedStrings
-        , QuasiQuotes
         , DefaultSignatures
         , ScopedTypeVariables
 
@@ -93,6 +92,7 @@ executable generate_readme
     other-modules: MultilineTh
     other-extensions: OverloadedStrings
                     , TemplateHaskell
+                    , QuasiQuotes
     if flag(buildReadme)
         buildable: True
     else


### PR DESCRIPTION
Right now `prettyprinter` can't be cross-compiled even as a library, because the `QuasiQuotes` extension is marked in `other-extensions`. This moves it to the appropriate stanza, so that the library can be used. 