### PR TITLE
Widen support to GHC-7.4...GHC-8.8

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,6 +26,9 @@
 - ignore: {name: "Use first"}
 - ignore: {name: "Use second"}
 
+# Use LambdaCase -- we cannot, GHC-7.6+ feature
+- ignore: {name: "Use lambda-case"}
+
 # Not all 3-liners should be deduplicated
 - ignore: {name: Reduce duplication, within: Data.Text.Prettyprint.Doc.Render.Terminal.Internal}
 

--- a/aux/version-compatibility-macros.h
+++ b/aux/version-compatibility-macros.h
@@ -14,7 +14,8 @@
 #define MONOID_IN_PRELUDE               MIN_VERSION_base(4,8,0)
 #define NATURAL_IN_BASE                 MIN_VERSION_base(4,8,0)
 
-#define MONAD_FAIL                      MIN_VERSION_base(4,9,0)
 #define SEMIGROUP_IN_BASE               MIN_VERSION_base(4,9,0)
+
+#define NO_FAIL_IN_MONAD_MONAD_FAIL     MIN_VERSION_base(4,13,0)
 
 #endif

--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -34,12 +34,11 @@ library
     default-language: Haskell2010
     other-extensions:
           CPP
-        , LambdaCase
         , OverloadedStrings
 
 
     build-depends:
-          base          >= 4.7 && < 5
+          base          >= 4.5 && < 5
         , ansi-terminal >= 0.4.0
         , text          >= 1.2
         , prettyprinter >= 1.1.1

--- a/prettyprinter-compat-annotated-wl-pprint/prettyprinter-compat-annotated-wl-pprint.cabal
+++ b/prettyprinter-compat-annotated-wl-pprint/prettyprinter-compat-annotated-wl-pprint.cabal
@@ -33,6 +33,6 @@ library
     other-extensions: CPP
 
     build-depends:
-          base          >= 4.7 && < 5
+          base          >= 4.5 && < 5
         , text          >= 1.2
         , prettyprinter >= 1

--- a/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
+++ b/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
@@ -17,9 +17,11 @@ module Text.PrettyPrint.Annotated.Leijen {-# DEPRECATED "Compatibility module fo
 
 ) where
 
-
-
+#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
+#else
+import Prelude
+#endif
 
 #if !(MONOID_IN_PRELUDE)
 import Data.Monoid hiding ((<>))

--- a/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
+++ b/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
@@ -30,11 +30,10 @@ library
     default-language: Haskell2010
     other-extensions:
           CPP
-        , LambdaCase
         , OverloadedStrings
 
     build-depends:
-          base                        >= 4.7 && < 5 && < 5
+          base                        >= 4.5 && < 5 && < 5
         , text                        >= 1.2
         , prettyprinter               >= 1
         , prettyprinter-ansi-terminal >= 1.1

--- a/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Text.PrettyPrint.ANSI.Leijen {-# DEPRECATED "Compatibility module for users of ansi-wl-pprint - use Data.Text.Prettyprint.Doc instead" #-} (
 
     Doc, putDoc, hPutDoc, empty, char, text, (<>), nest, line, linebreak, group,
@@ -17,9 +19,11 @@ module Text.PrettyPrint.ANSI.Leijen {-# DEPRECATED "Compatibility module for use
 
 ) where
 
-
-
+#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
+#else
+import Prelude
+#endif
 
 import           Data.Monoid
 import qualified Data.Text.Lazy as TL

--- a/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
+++ b/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
@@ -30,10 +30,9 @@ library
     default-language: Haskell2010
     other-extensions:
           CPP
-        , LambdaCase
         , OverloadedStrings
 
     build-depends:
-          base          >= 4.7 && < 5
+          base          >= 4.5 && < 5
         , text          >= 1.2
         , prettyprinter >= 1

--- a/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
+++ b/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Text.PrettyPrint.Leijen {-# DEPRECATED "Compatibility module for users of wl-pprint - use Data.Text.Prettyprint.Doc instead" #-} (
 
     Doc, putDoc, hPutDoc, empty, char, text, (<>), nest, line, linebreak, group,
@@ -14,7 +16,11 @@ module Text.PrettyPrint.Leijen {-# DEPRECATED "Compatibility module for users of
 
 
 
+#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
+#else
+import Prelude
+#endif
 
 import           Data.Monoid
 import qualified Data.Text.Lazy as TL

--- a/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
+++ b/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
@@ -30,11 +30,10 @@ library
     default-language: Haskell2010
     other-extensions:
           CPP
-        , LambdaCase
         , OverloadedStrings
 
     build-depends:
-          base                        >= 4.7 && < 5
+          base                        >= 4.5 && < 5
         , text                        >= 1.2
         , prettyprinter               >= 1
         , prettyprinter-ansi-terminal >= 1.1.1

--- a/prettyprinter-convert-ansi-wl-pprint/src/Data/Text/Prettyprint/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Data/Text/Prettyprint/Convert/AnsiWlPprint.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 -- | Convert back and forth between the 'Old.Doc' type of the @ansi-wl-pprint@
 -- and the 'New.Doc' of the prettyprinter package. Useful in order to use the
 -- @prettyprinter@ library together with another library that produces
@@ -34,7 +32,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen.Internal              as Old
 
 -- | @ansi-wl-pprint ───▷ prettyprinter@
 fromAnsiWlPprint :: Old.Doc -> New.Doc NewTerm.AnsiStyle
-fromAnsiWlPprint = \case
+fromAnsiWlPprint = \doc -> case doc of
     Old.Fail     -> New.Fail
     Old.Empty    -> New.Empty
     Old.Char c   -> New.Char c
@@ -87,7 +85,7 @@ fromAnsiWlPprint = \case
 
 -- | @prettyprinter ───▷ ansi-wl-pprint@
 toAnsiWlPprint :: New.Doc NewTerm.AnsiStyle -> Old.Doc
-toAnsiWlPprint = \case
+toAnsiWlPprint = \doc -> case doc of
     New.Fail     -> Old.Fail
     New.Empty    -> Old.Empty
     New.Char c   -> Old.Char c

--- a/prettyprinter/bench/LargeOutput.hs
+++ b/prettyprinter/bench/LargeOutput.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
 
-
+import Prelude        ()
+import Prelude.Compat
 
 import           Control.DeepSeq
-import           Control.Monad
+import           Control.Monad.Compat
 import           Criterion
 import           Criterion.Main
 import           Data.Char
@@ -98,7 +98,7 @@ instance Pretty LambdaForm where
         prettyExp = (<+> pretty body)
 
 instance Pretty Expr where
-    pretty = \case
+    pretty = \expr -> case expr of
         Let binds body ->
             align (vsep [ "let" <+> align (pretty binds)
                         , "in" <+> pretty body ])
@@ -141,7 +141,7 @@ instance WL.Pretty LambdaForm where
         prettyExp = (WL.<+> WL.pretty body)
 
 instance WL.Pretty Expr where
-    pretty = \case
+    pretty = \expr -> case expr of
         Let binds body ->
             WL.align (WL.vsep [ "let" WL.<+> WL.align (WL.pretty binds)
                         , "in" WL.<+> WL.pretty body ])

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -70,6 +70,7 @@ library
         ghc-options: -Wcompat
     if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.1
+        build-depends: fail >= 4.9.0.0 && < 4.10
     if !impl(ghc >= 7.10)
         build-depends: void
 

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -56,15 +56,17 @@ library
     other-extensions:
           BangPatterns
         , CPP
-        , LambdaCase
         , OverloadedStrings
         , QuasiQuotes
         , DefaultSignatures
         , ScopedTypeVariables
 
     build-depends:
-          base >= 4.7 && < 5
+          base >= 4.5 && < 5
         , text >= 1.2
+
+    if !impl(ghc >= 7.6)
+        build-depends: ghc-prim
 
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
@@ -142,7 +144,7 @@ benchmark fusion
     hs-source-dirs: bench
     main-is: Fusion.hs
     build-depends:
-          base >= 4.7 && < 5
+          base >= 4.5 && < 5
         , prettyprinter
 
         , criterion      >= 1.1
@@ -153,11 +155,11 @@ benchmark fusion
         , ansi-wl-pprint >= 0.6
     ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
     default-language: Haskell2010
-    other-extensions: NumDecimals, OverloadedStrings
+    other-extensions: OverloadedStrings
 
 benchmark faster-unsafe-text
     build-depends:
-          base >= 4.7 && < 5
+          base >= 4.5 && < 5
         , prettyprinter
 
         , criterion >= 1.1
@@ -172,7 +174,8 @@ benchmark faster-unsafe-text
 
 benchmark large-output
     build-depends:
-          base >= 4.7 && < 5
+          base >= 4.5 && < 5
+        , base-compat >=0.10.5 && <0.11
         , prettyprinter
         , ansi-wl-pprint
 
@@ -187,3 +190,9 @@ benchmark large-output
     ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
     default-language:    Haskell2010
     type:                exitcode-stdio-1.0
+
+    if !impl(ghc >= 7.6)
+        build-depends: ghc-prim
+
+    if !impl(ghc >= 8.0)
+        build-depends: semigroups

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Text.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Text.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 #include "version-compatibility-macros.h"
@@ -79,7 +78,7 @@ renderIO :: Handle -> SimpleDocStream ann -> IO ()
 renderIO h = go
   where
     go :: SimpleDocStream ann -> IO ()
-    go = \case
+    go = \sds -> case sds of
         SFail              -> panicUncaughtFail
         SEmpty             -> pure ()
         SChar c rest       -> do hPutChar h c

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/StackMachineTutorial.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/StackMachineTutorial.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
@@ -94,7 +93,7 @@ color c = annotate (Color c)
 -- The equivalent to this in the tree based rendering approach is
 -- 'Data.Text.Prettyprint.Doc.Render.Tutorials.TreeRenderingTutorial.renderTree'.
 renderStackMachine :: SimpleDocStream SimpleHtml -> StackMachine TLB.Builder SimpleHtml ()
-renderStackMachine = \case
+renderStackMachine = \sds -> case sds of
     SFail -> panicUncaughtFail
     SEmpty -> pure ()
     SChar c x -> do
@@ -119,7 +118,7 @@ renderStackMachine = \case
 -- | Convert a 'SimpleHtml' annotation to a pair of opening and closing tags.
 -- This is where the translation of style to raw output happens.
 htmlTag :: SimpleHtml -> (TLB.Builder, TLB.Builder)
-htmlTag = \case
+htmlTag = \sh -> case sh of
     Bold      -> ("<strong>", "</strong>")
     Italics   -> ("<em>", "</em>")
     Color c   -> ("<span style=\"color: " <> hexCode c <> "\">", "</span>")
@@ -127,7 +126,7 @@ htmlTag = \case
     Headline  -> ("<h1>", "</h1>")
   where
     hexCode :: Color -> TLB.Builder
-    hexCode = \case
+    hexCode = \c -> case c of
         Red   -> "#f00"
         Green -> "#0f0"
         Blue  -> "#00f"

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/TreeRenderingTutorial.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/TreeRenderingTutorial.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 #include "version-compatibility-macros.h"
@@ -91,7 +90,7 @@ render = TLB.toLazyText . renderTree . treeForm
 -- 'Data.Text.Prettyprint.Doc.Render.Tutorials.StackMachineTutorial.renderStackMachine'
 -- in the stack machine rendering tutorial.
 renderTree :: SimpleDocTree SimpleHtml -> TLB.Builder
-renderTree = \case
+renderTree sds = case sds of
     STEmpty -> mempty
     STChar c -> TLB.singleton c
     STText _ t -> TLB.fromText t
@@ -102,7 +101,7 @@ renderTree = \case
 -- | Convert a 'SimpleHtml' to a function that encloses a 'TLB.Builder' in HTML
 -- tags. This is where the translation of style to raw output happens.
 encloseInTagFor :: SimpleHtml -> TLB.Builder -> TLB.Builder
-encloseInTagFor = \case
+encloseInTagFor sh = case sh of
     Bold      -> \x -> "<strong>" <> x <> "</strong>"
     Italics   -> \x -> "<em>" <> x <> "</em>"
     Color c   -> \x -> "<span style=\"color: " <> hexCode c <> "\">" <> x <> "</span>"
@@ -110,7 +109,7 @@ encloseInTagFor = \case
     Headline  -> \x -> "<h1>" <> x <> "</h1>"
   where
     hexCode :: Color -> TLB.Builder
-    hexCode = \case
+    hexCode c = case c of
         Red   -> "#f00"
         Green -> "#0f0"
         Blue  -> "#00f"

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
@@ -34,9 +34,7 @@ import           GHC.Generics
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Util.Panic
 
-#if MONAD_FAIL
-import Control.Monad.Fail
-#endif
+import qualified Control.Monad.Fail as Fail
 
 #if !(MONOID_IN_PRELUDE)
 import Data.Monoid (Monoid (..))
@@ -127,12 +125,12 @@ instance Monad (UniqueParser s) where
         (a'', s'') <- runParser (f a') s'
         pure (a'', s'') )
 
-    fail _err = empty
-
-#if MONAD_FAIL
-instance MonadFail (UniqueParser s) where
-    fail _err = empty
+#if !(NO_FAIL_IN_MONAD_MONAD_FAIL)
+    fail = Fail.fail
 #endif
+
+instance Fail.MonadFail (UniqueParser s) where
+    fail _err = empty
 
 instance Alternative (UniqueParser s) where
     empty = UniqueParser (const empty)

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 #include "version-compatibility-macros.h"
@@ -145,7 +144,7 @@ pushStyle style = StackMachine (\styles -> ((), mempty, style : styles))
 --
 -- If the stack is empty, this raises an 'error'.
 unsafePopStyle :: Monoid output => StackMachine output style style
-unsafePopStyle = StackMachine (\case
+unsafePopStyle = StackMachine (\stack -> case stack of
     x:xs -> (x, mempty, xs)
     [] -> panicPoppedEmpty )
 

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 #include "version-compatibility-macros.h"
@@ -163,7 +162,7 @@ dampen gen = sized (\n -> resize ((n*2) `quot` 3) gen)
 
 docPerformanceTest :: Doc ann -> Assertion
 docPerformanceTest doc
-  = timeout 10000000 (forceDoc doc) >>= \case
+  = timeout 10000000 (forceDoc doc) >>= \doc' -> case doc' of
     Nothing -> assertFailure "Timeout!"
     Just _success -> pure ()
   where
@@ -204,5 +203,5 @@ regressionAlterAnnotationsS :: Assertion
 regressionAlterAnnotationsS
   = let sdoc, sdoc' :: SimpleDocStream Int
         sdoc = layoutSmart defaultLayoutOptions (annotate 1 (annotate 2 (annotate 3 "a")))
-        sdoc' = alterAnnotationsS (\case 2 -> Just 2; _ -> Nothing) sdoc
+        sdoc' = alterAnnotationsS (\ann -> case ann of 2 -> Just 2; _ -> Nothing) sdoc
     in assertEqual "" (SAnnPush 2 (SChar 'a' (SAnnPop SEmpty))) sdoc'


### PR DESCRIPTION
- GHC-8.8 is straight-forward `MONAD_NO_FAIL` fix
- GHC-7.4 + GHC-7.6 is trickier
  - **motivation** We'd like to use `prettyprinter` in `trifecta` and `criterion`, and it would be nice to keep support for older GHCs (especially for `criterion`). In this case the price is not that big.
  - no `LambdaCase`
  - and `AutoDeriveTypeable` -> `DataDeriveTypeable`
  - there's small problem, `pgp-wordlist` is `base >=4.6` (not `base >= 4.5`), but with `--allow-older=pgp-wordlist:base` it compiles fine.

There are few follow-ups which I'd like to do:
- extend `pgp-wordlist` support to GHC-7.4 too (should be simple)
- use [`haskell-ci`](https://github.com/haskell-ci/haskell-ci) for CI, so we can test old GHCs (and new!)
- split benchmarks into own package, because if/when `criterion` would depend on `prettyprint` there would be nasty package loop. Similar thing is done in e.g. https://github.com/haskell/containers/pull/626

cc @RyanGlScott
