### PR TITLE
Support GHC-7

### DIFF
--- a/aux/version-compatibility-macros.h
+++ b/aux/version-compatibility-macros.h
@@ -18,4 +18,6 @@
 
 #define NO_FAIL_IN_MONAD_MONAD_FAIL     MIN_VERSION_base(4,13,0)
 
+#define HAS_GENERICS                    __GLASGOW_HASKELL__ >= 702
+
 #endif

--- a/cabal.project
+++ b/cabal.project
@@ -6,5 +6,5 @@ packages: prettyprinter
         , prettyprinter-compat-ansi-wl-pprint
         , prettyprinter-convert-ansi-wl-pprint
         , prettyprinter-compat-annotated-wl-pprint
-tests: true
-benchmarks: true
+-- tests: true
+-- benchmarks: true

--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -36,9 +36,8 @@ library
           CPP
         , OverloadedStrings
 
-
     build-depends:
-          base          >= 4.5 && < 5
+          base          >= 4.3 && < 5
         , ansi-terminal >= 0.4.0
         , text          >= 1.2
         , prettyprinter >= 1.1.1

--- a/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal/Internal.hs
@@ -123,15 +123,15 @@ renderLazy sdoc = runST (do
     let push x = modifySTRef' styleStackRef (x :)
         unsafePeek = readSTRef styleStackRef >>= \tok -> case tok of
             []  -> panicPeekedEmpty
-            x:_ -> pure x
+            x:_ -> return x
         unsafePop = readSTRef styleStackRef >>= \tok -> case tok of
             []   -> panicPeekedEmpty
-            x:xs -> writeSTRef styleStackRef xs >> pure x
+            x:xs -> writeSTRef styleStackRef xs >> return x
         writeOutput x = modifySTRef outputRef (<> x)
 
     let go = \sds -> case sds of
             SFail -> panicUncaughtFail
-            SEmpty -> pure ()
+            SEmpty -> return ()
             SChar c rest -> do
                 writeOutput (TLB.singleton c)
                 go rest

--- a/prettyprinter-compat-annotated-wl-pprint/prettyprinter-compat-annotated-wl-pprint.cabal
+++ b/prettyprinter-compat-annotated-wl-pprint/prettyprinter-compat-annotated-wl-pprint.cabal
@@ -33,6 +33,6 @@ library
     other-extensions: CPP
 
     build-depends:
-          base          >= 4.5 && < 5
+          base          >= 4.3 && < 5
         , text          >= 1.2
         , prettyprinter >= 1

--- a/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
+++ b/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
@@ -24,7 +24,7 @@ import Prelude
 #endif
 
 #if !(MONOID_IN_PRELUDE)
-import Data.Monoid hiding ((<>))
+import Data.Monoid (Monoid (..))
 #endif
 
 import           Control.Applicative hiding (empty, (<$>))

--- a/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
+++ b/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 name:                prettyprinter-compat-ansi-wl-pprint
-version:             1.0.1
+version:             1.1
 cabal-version:       >= 1.10
 category:            User Interfaces, Text
 synopsis:            Drop-in compatibility package to migrate from »ansi-wl-pprint« to »prettyprinter«.
@@ -33,7 +33,10 @@ library
         , OverloadedStrings
 
     build-depends:
-          base                        >= 4.5 && < 5 && < 5
+          base                        >= 4.3 && < 5 && < 5
         , text                        >= 1.2
         , prettyprinter               >= 1
         , prettyprinter-ansi-terminal >= 1.1
+
+    if !impl(ghc >= 8.0)
+        build-depends: semigroups >= 0.6

--- a/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
@@ -25,7 +25,8 @@ import Prelude hiding ((<$>))
 import Prelude
 #endif
 
-import           Data.Monoid
+import           Data.Monoid (Monoid (..))
+import           Data.Semigroup ((<>))
 import qualified Data.Text.Lazy as TL
 import           System.IO
 

--- a/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
+++ b/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
@@ -1,5 +1,5 @@
 name:                prettyprinter-compat-wl-pprint
-version:             1.0.0.1
+version:             1.1
 cabal-version:       >= 1.10
 category:            User Interfaces, Text
 synopsis:            Drop-in compatibility package to migrate from »wl-pprint« to »prettyprinter«.
@@ -33,6 +33,9 @@ library
         , OverloadedStrings
 
     build-depends:
-          base          >= 4.5 && < 5
+          base          >= 4.3 && < 5
         , text          >= 1.2
         , prettyprinter >= 1
+
+    if !impl(ghc >= 8.0)
+        build-depends: semigroups >= 0.6

--- a/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
+++ b/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
@@ -22,7 +22,8 @@ import Prelude hiding ((<$>))
 import Prelude
 #endif
 
-import           Data.Monoid
+import           Data.Monoid    (Monoid (..))
+import           Data.Semigroup ((<>))
 import qualified Data.Text.Lazy as TL
 import           System.IO
 

--- a/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
+++ b/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
@@ -33,7 +33,7 @@ library
         , OverloadedStrings
 
     build-depends:
-          base                        >= 4.5 && < 5
+          base                        >= 4.3 && < 5
         , text                        >= 1.2
         , prettyprinter               >= 1
         , prettyprinter-ansi-terminal >= 1.1.1

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -57,11 +57,10 @@ library
           BangPatterns
         , CPP
         , OverloadedStrings
-        , DefaultSignatures
         , ScopedTypeVariables
 
     build-depends:
-          base >= 4.5 && < 5
+          base >= 4.3 && < 5
         , text >= 1.2
 
     if !impl(ghc >= 7.6)

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 #include "version-compatibility-macros.h"
+
+#if HAS_GENERICS
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE DeriveGeneric       #-}
+#endif
 
 -- | __Warning: internal module!__ This means that the API may change
 -- arbitrarily between versions without notice. Depending on this module may
@@ -32,7 +35,10 @@ import qualified Data.Text.Lazy      as Lazy
 import           Data.Typeable       (Typeable)
 import           Data.Void
 import           Data.Word
+
+#if HAS_GENERICS
 import           GHC.Generics        (Generic)
+#endif
 
 -- Depending on the Cabal file, this might be from base, or for older builds,
 -- from the semigroups package.
@@ -49,7 +55,7 @@ import Prelude          hiding (foldr, foldr1)
 #endif
 
 #if !(MONOID_IN_PRELUDE)
-import Data.Monoid hiding ((<>))
+import Data.Monoid (Monoid (..))
 #endif
 
 #if FUNCTOR_IDENTITY_IN_BASE
@@ -132,7 +138,11 @@ data Doc ann =
     -- | Add an annotation to the enclosed 'Doc'. Can be used for example to add
     -- styling directives or alt texts that can then be used by the renderer.
     | Annotated ann (Doc ann)
-    deriving (Generic, Typeable)
+    deriving (Typeable
+#if HAS_GENERIC
+        , Generic
+#endif
+        )
 
 -- |
 -- @
@@ -187,8 +197,10 @@ class Pretty a where
     -- 1 hello 1.234
     pretty :: a -> Doc ann
 
+#if HAS_GENERICS
     default pretty :: Show a => a -> Doc ann
     pretty = viaShow
+#endif
 
     -- | @'prettyList'@ is only used to define the @instance
     -- 'Pretty' a => 'Pretty' [a]@. In normal circumstances only the @'pretty'@
@@ -1440,7 +1452,11 @@ data SimpleDocStream ann =
 
     -- | Remove a previously pushed annotation.
     | SAnnPop (SimpleDocStream ann)
-    deriving (Eq, Ord, Show, Generic, Typeable)
+    deriving (Eq, Ord, Show, Typeable
+#if HAS_GENERIC
+        , Generic
+#endif
+        )
 
 -- | Remove all trailing space characters.
 --

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
 #include "version-compatibility-macros.h"
+
+#if HAS_GENERICS
+{-# LANGUAGE DeriveGeneric       #-}
+#endif
 
 -- | Conversion of the linked-list-like 'SimpleDocStream' to a tree-like
 -- 'SimpleDocTree'.
@@ -29,7 +32,10 @@ import           Control.Applicative
 import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           Data.Typeable       (Typeable)
+
+#if HAS_GENERICS
 import           GHC.Generics
+#endif
 
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Util.Panic
@@ -170,7 +176,11 @@ data SimpleDocTree ann
 
     -- | Horizontal concatenation of multiple documents.
     | STConcat [SimpleDocTree ann]
-    deriving (Eq, Ord, Show, Generic, Typeable)
+    deriving (Eq, Ord, Show, Typeable
+#if HAS_GENERIC
+        , Generic
+#endif
+        )
 
 -- | Alter the document’s annotations.
 --


### PR DESCRIPTION
This is untested.

I'd recommend to try to compile `optparse-applicative` `prettyprinter` patch with this version with GHC-7.0.4, to see how it works out.

Major bumps in `-compat` packages is due `Data.Monoid.<>` changing to `Data.Semigroup.<>`.