### PR TITLE
Don't fail when rendering an `Unbounded` layout of a `group`ed Line

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1535,6 +1535,14 @@ startsWithLine sds = case sds of
     SAnnPop s    -> startsWithLine s
     _            -> False
 
+-- | Test whether a docstream is 'SFail', ignoring any annotations.
+isFail :: SimpleDocStream ann -> Bool
+isFail sds = case sds of
+    SFail -> True
+    SAnnPush _ s -> isFail s
+    SAnnPop s -> isFail s
+    _ -> False
+
 
 -- $
 -- >>> import qualified Data.Text.IO as T
@@ -1794,6 +1802,7 @@ layoutWadlerLeijen
         -> SimpleDocStream ann -- ^ Choice B.
         -> SimpleDocStream ann -- ^ Choice A if it fits, otherwise B.
     selectNicer (FittingPredicate fits) lineIndent currentColumn x y
+      | isFail x = y
       | fits pWidth minNestingLevel availableWidth x = x
       | otherwise = y
       where

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -80,6 +80,8 @@ tests = testGroup "Tests"
             , testCase "Preserve leading indentation"
                        removeTrailingWhitespacePreserveIndentation
             ]
+        , testCase "Unbounded layout of `group`ed Line fails (#91)"
+                   regressionUnboundedGroupedLine
         ]
     ]
 
@@ -296,3 +298,9 @@ removeTrailingWhitespacePreserveIndentation
   = let sdoc :: SimpleDocStream ()
         sdoc = SLine 2 (SChar 'x' SEmpty)
     in assertEqual "" sdoc (removeTrailingWhitespace sdoc)
+
+regressionUnboundedGroupedLine :: Assertion
+regressionUnboundedGroupedLine
+  = let sdoc :: SimpleDocStream ()
+        sdoc = layoutPretty (LayoutOptions Unbounded) (group hardline)
+    in assertEqual "" (SLine 0 SEmpty) sdoc


### PR DESCRIPTION
~~Fixes~~ **Doesn't fix** #91.

---

TODO:

* [ ] Add a more complex test case
* [ ] Check whether any documentation needs updating or clarification.