### PR TITLE
Speed up changesUponFlattening

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -551,7 +551,7 @@ changesUponFlattening :: Doc ann -> Maybe (Doc ann)
 changesUponFlattening = \doc -> case doc of
     FlatAlt _ y     -> Just (flatten y)
     Line            -> Just Fail
-    Union x _       -> changesUponFlattening x <|> Just x
+    Union x _       -> Just x
     Nest i x        -> fmap (Nest i) (changesUponFlattening x)
     Annotated ann x -> fmap (Annotated ann) (changesUponFlattening x)
 


### PR DESCRIPTION
Since the first Union alternative was produced by the previous
call to to changesUponFlattening, it seems unnecessary to
scrutinize it again.

This speeds up some prettyprinter-heavy applications in dhall
by 20 to 42%.

This assumes some kind of idempotence in changesUponFlattening.

Fixes #99.