### PR TITLE
Remove scripts/ci/checks/hlint

### DIFF
--- a/scripts/ci/checks/hlint
+++ b/scripts/ci/checks/hlint
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-cd "$(stack path --project-root)"
-hlint --version
-hlint . --cpp-include=aux --cpp-define="MIN_VERSION_base(x,y,z) 1" --color


### PR DESCRIPTION
This script would fail in CI with

    ./scripts/ci/checks/hlint: line 6: hlint: command not found

See e.g. https://travis-ci.org/quchen/prettyprinter/jobs/634133471#L1091

The scripts/ci/install/hlint script remains and effectively
performs the HLint check.