### PR TITLE
Fix fusion of annotated documents

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1399,7 +1399,7 @@ fuse depth = go
         Nest 0 x         -> go x
         Nest i x         -> Nest i (go x)
 
-        Annotated _ Empty -> Empty
+        Annotated ann x -> Annotated ann (go x)
 
         FlatAlt x1 x2 -> FlatAlt (go x1) (go x2)
         Union x1 x2   -> Union (go x1) (go x2)


### PR DESCRIPTION
Fixes #108 

Changed the arbitary instance to also generate annotations and changed fuse to recurse to no longer remove the node if the content is empty. Now it recurses and keeps the annotation regardless of the underlying document.