### PR TITLE
Change group not to produce a Union when the document cannot be flattened

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -543,7 +543,7 @@ group x = case changesUponFlattening x of
 
 data FlattenResult a
     = Flattened a
-    -- ^ a is likely flatter than the input.
+    -- ^ @a@ is likely flatter than the input.
     | AlreadyFlat
     -- ^ The input was already flat, e.g. a 'Text'.
     | NeverFlat

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -581,7 +581,7 @@ changesUponFlattening = \doc -> case doc of
     Empty  -> Flat
     Char{} -> Flat
     Text{} -> Flat
-    Fail   -> Flat -- TODO: Or Unflattenable?!
+    Fail   -> Unflattenable
   where
     -- Flatten, but don’t report whether anything changes.
     flatten :: Doc ann -> Doc ann

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -526,7 +526,7 @@ group :: Doc ann -> Doc ann
 group x = case changesUponFlattening x of
     Flattened x'  -> Union x' x
     Flat          -> x
-    Unflattenable -> Union Fail x
+    Unflattenable -> x
 
 -- Note [Group: special flattening]
 --

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -543,8 +543,8 @@ group x = case changesUponFlattening x of
 
 data FlattenResult a
     = Flattened a
-    | Flat
-    | Unflattenable
+    | Flat          -- TODO: AlreadyFlat!?
+    | Unflattenable -- TODO: NeverFlat!?
 
 instance Functor FlattenResult where
     fmap f (Flattened a) = Flattened (f a)

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -542,15 +542,12 @@ group x = case changesUponFlattening x of
 -- ticket.
 
 data FlattenResult a
-
-    -- | a is likely flatter than the input.
     = Flattened a
-
-    -- | The input was already flat, e.g. a 'Text'.
+    -- ^ a is likely flatter than the input.
     | AlreadyFlat
-
-    -- | The input couldn't be flattened: It contained a 'Line' or 'Fail'.
+    -- ^ The input was already flat, e.g. a 'Text'.
     | NeverFlat
+    -- ^ The input couldn't be flattened: It contained a 'Line' or 'Fail'.
 
 instance Functor FlattenResult where
     fmap f (Flattened a) = Flattened (f a)

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -564,7 +564,7 @@ instance Functor FlattenResult where
 -- algorithm (i.e. contains differently renderable sub-documents), and 'AlreadyFlat'
 -- if the document is static (e.g. contains only a plain 'Empty' node).
 -- 'NeverFlat' is returned when the document cannot be flattened because it
--- contains a 'Line' or 'Fail'.
+-- contains a hard 'Line' or 'Fail'.
 -- See [Group: special flattening] for further explanations.
 changesUponFlattening :: Doc ann -> FlattenResult (Doc ann)
 changesUponFlattening = \doc -> case doc of


### PR DESCRIPTION
Fixes #99, fixes #112.