### PR TITLE
Use gauge instead of criterion for benchmarks

### DIFF
--- a/prettyprinter/bench/FasterUnsafeText.hs
+++ b/prettyprinter/bench/FasterUnsafeText.hs
@@ -4,7 +4,7 @@ module Main (main) where
 
 
 
-import           Criterion.Main
+import           Gauge.Main
 import           Data.Char
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T

--- a/prettyprinter/bench/Fusion.hs
+++ b/prettyprinter/bench/Fusion.hs
@@ -9,7 +9,7 @@ module Main (main) where
 
 import           Control.Monad
 import           Control.Monad.State
-import           Criterion.Main
+import           Gauge.Main
 import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           System.Random
@@ -31,9 +31,9 @@ main = defaultMain
     ]
 
 benchOptimize :: Benchmark
-benchOptimize = env randomShortWords benchmark
+benchOptimize = env randomShortWords benchmark_
   where
-    benchmark = \shortWords ->
+    benchmark_ = \shortWords ->
         let doc = hsep (map pretty shortWords)
         in bgroup "Many small words"
             [ bench "Unoptimized"     (nf renderLazy (layoutPretty defaultLayoutOptions               doc))

--- a/prettyprinter/bench/LargeOutput.hs
+++ b/prettyprinter/bench/LargeOutput.hs
@@ -10,8 +10,7 @@ import Prelude.Compat
 
 import           Control.DeepSeq
 import           Control.Monad.Compat
-import           Criterion
-import           Criterion.Main
+import           Gauge
 import           Data.Char
 import           Data.Map                              (Map)
 import qualified Data.Map                              as M

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -145,7 +145,7 @@ benchmark fusion
           base >= 4.5 && < 5
         , prettyprinter
 
-        , criterion      >= 1.1
+        , gauge          >= 0.2
         , mtl            >= 2.1
         , random         >= 1.0
         , text
@@ -160,7 +160,7 @@ benchmark faster-unsafe-text
           base >= 4.5 && < 5
         , prettyprinter
 
-        , criterion >= 1.1
+        , gauge >= 0.2
         , text
 
     hs-source-dirs:      bench
@@ -177,7 +177,7 @@ benchmark large-output
         , prettyprinter
         , ansi-wl-pprint
 
-        , criterion  >= 1.1
+        , gauge >= 0.2
         , QuickCheck >= 2.7
         , containers
         , text


### PR DESCRIPTION
… mostly because gauge builds much faster.