### PR TITLE
Write symbols as ordinary Doc literals

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
@@ -46,65 +46,65 @@ braces = enclose lbrace rbrace
 -- | >>> squote
 -- '
 squote :: Doc ann
-squote = "'"
+squote = Char '\''
 
 -- | >>> dquote
 -- "
 dquote :: Doc ann
-dquote = "\""
+dquote = Char '"'
 
 -- | >>> lparen
 -- (
 lparen :: Doc ann
-lparen = "("
+lparen = Char '('
 
 -- | >>> rparen
 -- )
 rparen :: Doc ann
-rparen = ")"
+rparen = Char ')'
 
 -- | >>> langle
 -- <
 langle :: Doc ann
-langle = "<"
+langle = Char '<'
 
 -- | >>> rangle
 -- >
 rangle :: Doc ann
-rangle = ">"
+rangle = Char '>'
 
 -- | >>> lbracket
 -- [
 lbracket :: Doc ann
-lbracket = "["
+lbracket = Char '['
 -- | >>> rbracket
 -- ]
 rbracket :: Doc ann
-rbracket = "]"
+rbracket = Char ']'
 
 -- | >>> lbrace
 -- {
 lbrace :: Doc ann
-lbrace = "{"
+lbrace = Char '{'
 -- | >>> rbrace
 -- }
 rbrace :: Doc ann
-rbrace = "}"
+rbrace = Char '}'
 
 -- | >>> semi
 -- ;
 semi :: Doc ann
-semi = ";"
+semi = Char ';'
 
 -- | >>> colon
 -- :
 colon :: Doc ann
-colon = ":"
+colon = Char ':'
 
 -- | >>> comma
 -- ,
 comma :: Doc ann
-comma = ","
+comma = Char ','
 
 -- | >>> "a" <> space <> "b"
 -- a b
@@ -114,17 +114,17 @@ comma = ","
 -- >>> "a" <+> "b"
 -- a b
 space :: Doc ann
-space = " "
+space = Char ' '
 
 -- | >>> dot
 -- .
 dot :: Doc ann
-dot = "."
+dot = Char '.'
 
 -- | >>> slash
 -- /
 slash :: Doc ann
-slash = "/"
+slash = Char '/'
 
 -- | >>> backslash
 -- \\
@@ -135,12 +135,12 @@ backslash = "\\"
 -- | >>> equals
 -- =
 equals :: Doc ann
-equals = "="
+equals = Char '='
 
 -- | >>> pipe
 -- |
 pipe :: Doc ann
-pipe = "|"
+pipe = Char '|'
 
 
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
@@ -106,100 +106,100 @@ sGuillemetsIn = enclose rsGuillemet lsGuillemet
 -- >>> putDoc b99dquote
 -- „
 b99dquote :: Doc ann
-b99dquote = "„"
+b99dquote = Char '„'
 
 -- | Top “66” style double quotes.
 --
 -- >>> putDoc t66dquote
 -- “
 t66dquote :: Doc ann
-t66dquote = "“"
+t66dquote = Char '“'
 
 -- | Top “99” style double quotes.
 --
 -- >>> putDoc t99dquote
 -- ”
 t99dquote :: Doc ann
-t99dquote = "”"
+t99dquote = Char '”'
 
 -- | Bottom ‚9‘ style single quote.
 --
 -- >>> putDoc b9quote
 -- ‚
 b9quote :: Doc ann
-b9quote = "‚"
+b9quote = Char '‚'
 
 -- | Top ‘66’ style single quote.
 --
 -- >>> putDoc t6quote
 -- ‘
 t6quote :: Doc ann
-t6quote = "‘"
+t6quote = Char '‘'
 
 -- | Top ‘9’ style single quote.
 --
 -- >>> putDoc t9quote
 -- ’
 t9quote :: Doc ann
-t9quote = "’"
+t9quote = Char '’'
 
 -- | Right-pointing double guillemets
 --
 -- >>> putDoc rdGuillemet
 -- »
 rdGuillemet :: Doc ann
-rdGuillemet = "»"
+rdGuillemet = Char '»'
 
 -- | Left-pointing double guillemets
 --
 -- >>> putDoc ldGuillemet
 -- «
 ldGuillemet :: Doc ann
-ldGuillemet = "«"
+ldGuillemet = Char '«'
 
 -- | Right-pointing single guillemets
 --
 -- >>> putDoc rsGuillemet
 -- ›
 rsGuillemet :: Doc ann
-rsGuillemet = "›"
+rsGuillemet = Char '›'
 
 -- | Left-pointing single guillemets
 --
 -- >>> putDoc lsGuillemet
 -- ‹
 lsGuillemet :: Doc ann
-lsGuillemet = "‹"
+lsGuillemet = Char '‹'
 
 -- | >>> putDoc bullet
 -- •
 bullet :: Doc ann
-bullet = "•"
+bullet = Char '•'
 
 -- | >>> putDoc endash
 -- –
 endash :: Doc ann
-endash = "–"
+endash = Char '–'
 
 -- | >>> putDoc euro
 -- €
 euro :: Doc ann
-euro = "€"
+euro = Char '€'
 
 -- | >>> putDoc cent
 -- ¢
 cent :: Doc ann
-cent = "¢"
+cent = Char '¢'
 
 -- | >>> putDoc yen
 -- ¥
 yen :: Doc ann
-yen = "¥"
+yen = Char '¥'
 
 -- | >>> putDoc pound
 -- £
 pound :: Doc ann
-pound = "£"
+pound = Char '£'
 
 
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
@@ -41,7 +41,7 @@ module Data.Text.Prettyprint.Doc.Symbols.Unicode (
 
 
 
-import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Internal
 
 
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | A collection of predefined Unicode values outside of ASCII range. For
 -- ASCII, see "Data.Text.Prettyprint.Doc.Symbols.Ascii".
 module Data.Text.Prettyprint.Doc.Symbols.Unicode (


### PR DESCRIPTION
This addresses https://github.com/quchen/prettyprinter/issues/131#issuecomment-578348811.