### PR TITLE
RFC: A different approach to avoiding trailing whitespace

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1968,6 +1968,9 @@ layoutWadlerLeijen
         Char c          -> let !cc' = cc+1 in SChar c (best nl cc' ds)
         Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
         Line            -> let x = best i i ds
+                               -- Don't produce indentation if there's no
+                               -- following text on the same line.
+                               -- This prevents trailing whitespace.
                                i' = case x of
                                    SEmpty  -> 0
                                    SLine{} -> 0

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1967,7 +1967,11 @@ layoutWadlerLeijen
         Empty           -> best nl cc ds
         Char c          -> let !cc' = cc+1 in SChar c (best nl cc' ds)
         Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
-        Line            -> SLine i (best i i ds)
+        Line            -> let x = best i i ds
+                               i' = case x of
+                                   SLine{} -> 0
+                                   _       -> i
+                           in SLine i' x
         FlatAlt x _     -> best nl cc (Cons i x ds)
         Cat x y         -> best nl cc (Cons i x (Cons i y ds))
         Nest j x        -> let !ij = i+j in best nl cc (Cons ij x ds)

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1969,6 +1969,7 @@ layoutWadlerLeijen
         Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
         Line            -> let x = best i i ds
                                i' = case x of
+                                   SEmpty  -> 0
                                    SLine{} -> 0
                                    _       -> i
                            in SLine i' x

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1950,7 +1950,7 @@ layoutWadlerLeijen
     (FittingPredicate fits)
     pageWidth_
     doc
-  = best 0 0 (Cons 0 doc Nil)
+  = best 0 0 0 (Cons 0 doc Nil)
   where
 
     -- * current column >= current nesting level
@@ -1958,34 +1958,38 @@ layoutWadlerLeijen
     best
         :: Int -- Current nesting level
         -> Int -- Current column, i.e. "where the cursor is"
+        -> Int -- Current annotation nesting level
         -> LayoutPipeline ann -- Documents remaining to be handled (in order)
         -> SimpleDocStream ann
-    best !_ !_ Nil           = SEmpty
-    best nl cc (UndoAnn ds)  = SAnnPop (best nl cc ds)
-    best nl cc (Cons i d ds) = case d of
+    best !_ !_ !_ Nil           = SEmpty
+    best nl cc an (UndoAnn ds)  = SAnnPop (best nl cc (an-1) ds)
+    best nl cc an (Cons i d ds) = case d of
         Fail            -> SFail
-        Empty           -> best nl cc ds
-        Char c          -> let !cc' = cc+1 in SChar c (best nl cc' ds)
-        Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
-        Line            -> let x = best i i ds
+        Empty           -> best nl cc an ds
+        Char c          -> let !cc' = cc+1 in SChar c (best nl cc' an ds)
+        Text l t        -> let !cc' = cc+l in SText l t (best nl cc' an ds)
+        Line            -> let x = best i i an ds
                                -- Don't produce indentation if there's no
                                -- following text on the same line.
                                -- This prevents trailing whitespace.
-                               i' = case x of
-                                   SEmpty  -> 0
-                                   SLine{} -> 0
-                                   _       -> i
+                               i' =
+                                   if an > 0
+                                       then i
+                                       else case x of
+                                           SEmpty  -> 0
+                                           SLine{} -> 0
+                                           _       -> i
                            in SLine i' x
-        FlatAlt x _     -> best nl cc (Cons i x ds)
-        Cat x y         -> best nl cc (Cons i x (Cons i y ds))
-        Nest j x        -> let !ij = i+j in best nl cc (Cons ij x ds)
-        Union x y       -> let x' = best nl cc (Cons i x ds)
-                               y' = best nl cc (Cons i y ds)
+        FlatAlt x _     -> best nl cc an (Cons i x ds)
+        Cat x y         -> best nl cc an (Cons i x (Cons i y ds))
+        Nest j x        -> let !ij = i+j in best nl cc an (Cons ij x ds)
+        Union x y       -> let x' = best nl cc an (Cons i x ds)
+                               y' = best nl cc an (Cons i y ds)
                            in selectNicer nl cc x' y'
-        Column f        -> best nl cc (Cons i (f cc) ds)
-        WithPageWidth f -> best nl cc (Cons i (f pageWidth_) ds)
-        Nesting f       -> best nl cc (Cons i (f i) ds)
-        Annotated ann x -> SAnnPush ann (best nl cc (Cons i x (UndoAnn ds)))
+        Column f        -> best nl cc an (Cons i (f cc) ds)
+        WithPageWidth f -> best nl cc an (Cons i (f pageWidth_) ds)
+        Nesting f       -> best nl cc an (Cons i (f i) ds)
+        Annotated ann x -> SAnnPush ann (best nl cc (an+1) (Cons i x (UndoAnn ds)))
 
     -- Select the better fitting of two documents:
     -- Choice A if it fits, otherwise choice B.

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -89,6 +89,8 @@ tests = testGroup "Tests"
             , testCase "Line within align" regressionUnboundedGroupedLineWithinAlign
             ]
         ]
+        , testCase "Indentation on otherwise empty lines results in trailing whitespace (#139)"
+                   indentationShouldntCauseTrailingWhitespaceOnOtherwiseEmptyLines
     ]
 
 fusionDoesNotChangeRendering :: FusionDepth -> Property
@@ -379,4 +381,12 @@ regressionUnboundedGroupedLineWithinAlign
         doc = group (align ("x" <> hardline <> "y"))
         sdoc = layoutPretty (LayoutOptions Unbounded) doc
         expected = SChar 'x' (SLine 0 (SChar 'y' SEmpty))
+    in assertEqual "" expected sdoc
+
+indentationShouldntCauseTrailingWhitespaceOnOtherwiseEmptyLines :: Assertion
+indentationShouldntCauseTrailingWhitespaceOnOtherwiseEmptyLines
+  = let doc :: Doc ()
+        doc = indent 1 ("x" <> hardline <> hardline <> "y" <> hardline)
+        sdoc = layoutPretty (LayoutOptions Unbounded) doc
+        expected = SChar ' ' (SChar 'x' (SLine 0 (SLine 1 (SChar 'y' (SLine 0 SEmpty)))))
     in assertEqual "" expected sdoc


### PR DESCRIPTION
[`removeTrailingWhitespace`](https://github.com/quchen/prettyprinter/blob/8b9b1767bc10a438a75a0be19b841ace7aa6e6a8/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs#L1466-L1538) was introduced in response to the issue of trailing whitespace on otherwise empty lines in the output of `dhall` (#46).

`removeTrailingWhitespace` does quite a bit more than just remove whitespace on otherwise empty lines though:

* It also strips `SText` and `SChar` of any trailing whitespace.
* It keeps track of any surrounding annotations and avoids stripping whitespace inside annotations.

These extra features are also useful, but they aren't needed to address the original issue.

This patch addresses the original issue more directly: When we encounter a `Line` during layout, we check how the document continues before adding any indentation.

This is sufficient to address the original issue in `dhall`.

What I'm currently unsure about is the importance of annotations: Would this break any documents that try to highlight whitespace?! 

---

TODO:

* [x] Benchmarking
* [x] Tests
* [ ] Documentation for `rTW`
* [ ] Documentation for `indent`

Travis status, since Github doesn't show it: https://travis-ci.org/github/quchen/prettyprinter/pull_requests