### PR TITLE
Enable -O2 for prettyprinter[-ansi-terminal]

### DIFF
--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -28,7 +28,7 @@ source-repository head
 library
     exposed-modules:  Data.Text.Prettyprint.Doc.Render.Terminal
                     , Data.Text.Prettyprint.Doc.Render.Terminal.Internal
-    ghc-options:      -Wall
+    ghc-options:      -Wall -O2
     hs-source-dirs:   src
     include-dirs:     misc
     default-language: Haskell2010

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -44,7 +44,7 @@ library
         -- Deprecated
         , Data.Text.Prettyprint.Doc.Render.ShowS
 
-    ghc-options: -Wall
+    ghc-options: -Wall -O2
     hs-source-dirs: src
     include-dirs: misc
     default-language: Haskell2010


### PR DESCRIPTION
This seems to speed up my `dhall` benchmark a bit.

https://github.com/quchen/prettyprinter/issues/143#issuecomment-581163419 also gives some evidence that this might be beneficial.