### PR TITLE
Compute ribbon width with `floor` instead of `round`

### DIFF
--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1775,7 +1775,7 @@ remainingWidth lineLength ribbonFraction lineIndent currentColumn =
     columnsLeftInLine = lineLength - currentColumn
     columnsLeftInRibbon = lineIndent + ribbonWidth - currentColumn
     ribbonWidth =
-        (max 0 . min lineLength . round)
+        (max 0 . min lineLength . floor)
             (fromIntegral lineLength * ribbonFraction)
 
 -- $ Test to avoid surprising behaviour

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -88,9 +88,11 @@ tests = testGroup "Tests"
             [ testCase "Line" regressionUnboundedGroupedLine
             , testCase "Line within align" regressionUnboundedGroupedLineWithinAlign
             ]
-        ]
         , testCase "Indentation on otherwise empty lines results in trailing whitespace (#139)"
                    indentationShouldntCauseTrailingWhitespaceOnOtherwiseEmptyLines
+        , testCase "Ribbon width should be computed with `floor` instead of `round` (#157)"
+                   computeRibbonWidthWithFloor
+        ]
     ]
 
 fusionDoesNotChangeRendering :: FusionDepth -> Property
@@ -389,4 +391,12 @@ indentationShouldntCauseTrailingWhitespaceOnOtherwiseEmptyLines
         doc = indent 1 ("x" <> hardline <> hardline <> "y" <> hardline)
         sdoc = layoutPretty (LayoutOptions Unbounded) doc
         expected = SChar ' ' (SChar 'x' (SLine 0 (SLine 1 (SChar 'y' (SLine 0 SEmpty)))))
+    in assertEqual "" expected sdoc
+
+computeRibbonWidthWithFloor :: Assertion
+computeRibbonWidthWithFloor
+  = let doc :: Doc ()
+        doc = "a" <> softline' <> "b"
+        sdoc = layoutPretty (LayoutOptions (AvailablePerLine 3 0.5)) doc
+        expected = SChar 'a' (SLine 0 (SChar 'b' SEmpty))
     in assertEqual "" expected sdoc


### PR DESCRIPTION
`floor` seems like the more appropriate method to handle fractional ribbon widths. E.g. when the ribbon width is 7.5, we don't want to allow a ribbon of 8 columns.

Fixes #157.