### PR TITLE
Import old modules for better compatibility with old prettyprinter versions

### DIFF
--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
@@ -51,8 +51,8 @@ import qualified Data.Text.Lazy.Builder as TLB
 import qualified System.Console.ANSI    as ANSI
 import           System.IO              (Handle, hPutChar, stdout)
 
-import Prettyprinter
-import Prettyprinter.Render.Util.Panic
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Util.Panic
 
 #if !(SEMIGROUP_MONOID_SUPERCLASS)
 import Data.Semigroup

--- a/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
@@ -23,8 +23,8 @@ module Prettyprinter.Convert.AnsiWlPprint (
 
 import qualified Data.Text as T
 
-import qualified Prettyprinter.Internal                 as New
-import qualified Prettyprinter.Render.Terminal.Internal as NewTerm
+import qualified Data.Text.Prettyprint.Doc.Internal                 as New
+import qualified Data.Text.Prettyprint.Doc.Render.Terminal.Internal as NewTerm
 import qualified System.Console.ANSI                                as Ansi
 import qualified Text.PrettyPrint.ANSI.Leijen.Internal              as Old
 


### PR DESCRIPTION
This is a follow-up to #174.