### PR TITLE
Generalise specialisations of `concatWith` from list to `Foldable`

### DIFF
--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -972,7 +972,7 @@ concatWith f ds
 -- lorem ipsum dolor sit amet
 --
 -- For automatic line breaks, consider using 'fillSep' instead.
-hsep :: [Doc ann] -> Doc ann
+hsep :: Foldable t => t (Doc ann) -> Doc ann
 hsep = concatWith (<+>)
 
 -- | @('vsep' xs)@ concatenates all documents @xs@ above each other. If a
@@ -1002,7 +1002,7 @@ hsep = concatWith (<+>)
 --
 -- Since 'group'ing a 'vsep' is rather common, 'sep' is a built-in for doing
 -- that.
-vsep :: [Doc ann] -> Doc ann
+vsep :: Foldable t => t (Doc ann) -> Doc ann
 vsep = concatWith (\x y -> x <> line <> y)
 
 -- | @('fillSep' xs)@ concatenates the documents @xs@ horizontally with @'<+>'@
@@ -1024,7 +1024,7 @@ vsep = concatWith (\x y -> x <> line <> y)
 -- Docs: lorem ipsum dolor sit amet lorem
 -- ipsum dolor sit amet lorem ipsum dolor
 -- sit amet lorem ipsum dolor sit amet
-fillSep :: [Doc ann] -> Doc ann
+fillSep :: Foldable t => t (Doc ann) -> Doc ann
 fillSep = concatWith (\x y -> x <> softline <> y)
 
 -- | @('sep' xs)@ tries laying out the documents @xs@ separated with 'space's,
@@ -1060,7 +1060,7 @@ sep = group . vsep
 -- >>> let docs = Util.words "lorem ipsum dolor"
 -- >>> hcat docs
 -- loremipsumdolor
-hcat :: [Doc ann] -> Doc ann
+hcat :: Foldable t => t (Doc ann) -> Doc ann
 hcat = concatWith (<>)
 
 -- | @('vcat' xs)@ vertically concatenates the documents @xs@. If it is
@@ -1079,7 +1079,7 @@ hcat = concatWith (<>)
 --
 -- Since 'group'ing a 'vcat' is rather common, 'cat' is a built-in shortcut for
 -- it.
-vcat :: [Doc ann] -> Doc ann
+vcat :: Foldable t => t (Doc ann) -> Doc ann
 vcat = concatWith (\x y -> x <> line' <> y)
 
 -- | @('fillCat' xs)@ concatenates documents @xs@ horizontally with @'<>'@ as
@@ -1108,7 +1108,7 @@ vcat = concatWith (\x y -> x <> line' <> y)
 -- Grouped: loremipsumdolorsitametlorem
 -- ipsumdolorsitametloremipsumdolorsitamet
 -- loremipsumdolorsitamet
-fillCat :: [Doc ann] -> Doc ann
+fillCat :: Foldable t => t (Doc ann) -> Doc ann
 fillCat = concatWith (\x y -> x <> softline' <> y)
 
 -- | @('cat' xs)@ tries laying out the documents @xs@ separated with nothing,


### PR DESCRIPTION
I'm trying to use these with the `NonEmpty` type rather than lists. I'm unsure whether I should be adding `SPECIALIZE` pragmas underneath in the same way as is done with `concatWith`?