### PR TITLE
Make text an optional dependency

### DIFF
--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -32,5 +32,5 @@ jobs:
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}
-    - name: Build
-      run: cabal build -f-text prettyprinter:prettyprinter
+    - name: Test
+      run: cabal test -f-text prettyprinter:test:testsuite

--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -32,5 +32,5 @@ jobs:
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}
-    - name: Test
-      run: cabal test -f-text prettyprinter:test:testsuite
+    - name: Build
+      run: cabal build -f-text prettyprinter:prettyprinter

--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -1,0 +1,36 @@
+name: no-text
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        ghc: ['latest', '7.10']
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell-cabal
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - name: Update cabal package database
+      run: cabal update
+    - uses: actions/cache@v2
+      name: Cache cabal stuff
+      with:
+        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}
+    - name: Build
+      run: cabal build -f-text prettyprinter:prettyprinter

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -1,6 +1,6 @@
 name:                prettyprinter
 version:             1.7.0
-cabal-version:       >= 1.10
+cabal-version:       2.0
 category:            User Interfaces, Text
 synopsis:            A modern, easy to use, well-documented, extensible pretty-printer.
 description:         A modern, easy to use, well-documented, extensible pretty-printer. For more see README.md
@@ -73,13 +73,7 @@ library
     if flag(text)
         build-depends: text >= 1.2
     else
-        -- A fake text package, emulating the same API, but backed by String
-        hs-source-dirs: src-text
-        other-modules:
-              Data.Text
-            , Data.Text.IO
-            , Data.Text.Lazy
-            , Data.Text.Lazy.Builder
+        build-depends: fake-text
 
     if !impl(ghc >= 7.6)
         build-depends: ghc-prim
@@ -92,7 +86,19 @@ library
     if !impl(ghc >= 7.10)
         build-depends: void >=0.4 && <0.8
 
-
+-- A fake text package, emulating the same API, but backed by String
+library fake-text
+    build-depends: base
+    ghc-options: -Wall -O2
+    default-language: Haskell2010
+    hs-source-dirs: src-text
+    exposed-modules:
+          Data.Text
+        , Data.Text.IO
+        , Data.Text.Lazy
+        , Data.Text.Lazy.Builder
+    if flag(text)
+        buildable: False
 
 Flag buildReadme
   Description: Build the readme generator
@@ -158,16 +164,16 @@ test-suite testsuite
         , tasty            >= 0.10
         , tasty-hunit      >= 0.9
         , tasty-quickcheck >= 0.8
-        , text
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
     default-language: Haskell2010
 
     if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.6
 
-    if !flag(text)
-        buildable: False
-
+    if flag(text)
+        build-depends: text
+    else
+        build-depends: fake-text
 
 benchmark fusion
     type: exitcode-stdio-1.0

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -69,7 +69,17 @@ library
 
     build-depends:
           base >= 4.5 && < 5
-        , text >= 1.2
+
+    if flag(text)
+        build-depends: text >= 1.2
+    else
+        -- A fake text package, emulating the same API, but backed by String
+        hs-source-dirs: src-text
+        other-modules:
+              Data.Text
+            , Data.Text.IO
+            , Data.Text.Lazy
+            , Data.Text.Lazy.Builder
 
     if !impl(ghc >= 7.6)
         build-depends: ghc-prim
@@ -88,6 +98,14 @@ Flag buildReadme
   Description: Build the readme generator
   Default:     False
 
+Flag text
+  Description: While it's a core value of @prettyprinter@ to use @Text@, there are rare
+               circumstances (mostly when @prettyprinter@ arises as a dependency of
+               test suites of packages like @bytestring@ or @text@ themselves) when
+               this is inconvenient. In this case one can disable this flag, so that
+               @prettyprinter@ fallbacks to @String@.
+  Default:     True
+
 
 executable generate_readme
     hs-source-dirs: app
@@ -103,7 +121,7 @@ executable generate_readme
     other-extensions: OverloadedStrings
                     , TemplateHaskell
                     , QuasiQuotes
-    if flag(buildReadme)
+    if flag(buildReadme) && flag(text)
         buildable: True
     else
         buildable: False
@@ -147,6 +165,8 @@ test-suite testsuite
     if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.6
 
+    if !flag(text)
+        buildable: False
 
 
 benchmark fusion
@@ -167,6 +187,9 @@ benchmark fusion
     default-language: Haskell2010
     other-extensions: OverloadedStrings
 
+    if !flag(text)
+        buildable: False
+
 benchmark faster-unsafe-text
     build-depends:
           base >= 4.5 && < 5
@@ -181,6 +204,8 @@ benchmark faster-unsafe-text
     default-language:    Haskell2010
     type:                exitcode-stdio-1.0
 
+    if !flag(text)
+        buildable: False
 
 benchmark large-output
     build-depends:
@@ -206,3 +231,6 @@ benchmark large-output
 
     if !impl(ghc >= 8.0)
         build-depends: semigroups
+
+    if !flag(text)
+        buildable: False

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -1,6 +1,6 @@
 name:                prettyprinter
 version:             1.7.0
-cabal-version:       2.0
+cabal-version:       >= 1.10
 category:            User Interfaces, Text
 synopsis:            A modern, easy to use, well-documented, extensible pretty-printer.
 description:         A modern, easy to use, well-documented, extensible pretty-printer. For more see README.md
@@ -73,7 +73,13 @@ library
     if flag(text)
         build-depends: text >= 1.2
     else
-        build-depends: fake-text
+        -- A fake text package, emulating the same API, but backed by String
+        hs-source-dirs: src-text
+        other-modules:
+              Data.Text
+            , Data.Text.IO
+            , Data.Text.Lazy
+            , Data.Text.Lazy.Builder
 
     if !impl(ghc >= 7.6)
         build-depends: ghc-prim
@@ -86,19 +92,7 @@ library
     if !impl(ghc >= 7.10)
         build-depends: void >=0.4 && <0.8
 
--- A fake text package, emulating the same API, but backed by String
-library fake-text
-    build-depends: base
-    ghc-options: -Wall -O2
-    default-language: Haskell2010
-    hs-source-dirs: src-text
-    exposed-modules:
-          Data.Text
-        , Data.Text.IO
-        , Data.Text.Lazy
-        , Data.Text.Lazy.Builder
-    if flag(text)
-        buildable: False
+
 
 Flag buildReadme
   Description: Build the readme generator
@@ -164,16 +158,16 @@ test-suite testsuite
         , tasty            >= 0.10
         , tasty-hunit      >= 0.9
         , tasty-quickcheck >= 0.8
+        , text
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
     default-language: Haskell2010
 
     if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.6
 
-    if flag(text)
-        build-depends: text
-    else
-        build-depends: fake-text
+    if !flag(text)
+        buildable: False
+
 
 benchmark fusion
     type: exitcode-stdio-1.0

--- a/prettyprinter/src-text/Data/Text.hs
+++ b/prettyprinter/src-text/Data/Text.hs
@@ -1,0 +1,46 @@
+-- Provide a fake API, mimicking Data.Text from text package,
+-- but actually backed by type Text = String. It is used only in rare
+-- circumstances, when prettyprinter is built with -text flag.
+--
+
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Data.Text where
+
+import Prelude hiding (head, length, null, replicate)
+import qualified Data.Char
+import qualified Data.List
+
+type Text = String
+cons = (:)
+dropWhileEnd = Data.List.dropWhileEnd
+head = Data.List.head
+intercalate = Data.List.intercalate
+length = Data.List.length :: [Char] -> Int
+lines = Data.List.lines
+map = Data.List.map
+null = Data.List.null :: [Char] -> Bool
+pack = id
+replicate = (Data.List.concat .) . Data.List.replicate
+singleton = (:[])
+snoc xs x = xs ++ [x]
+stripEnd = dropWhileEnd Data.Char.isSpace
+unlines = Data.List.unlines
+unpack = id
+words = Data.List.words
+
+uncons :: Text -> Maybe (Char, Text)
+uncons [] = Nothing
+uncons (x : xs) = Just (x, xs)
+
+splitOn :: Text -> Text -> [Text]
+splitOn pat src
+  | null pat = error "splitOn: empty pattern"
+  | otherwise = go [] src
+  where
+    go acc [] = [reverse acc]
+    go acc xs@(y : ys)
+      | pat `Data.List.isPrefixOf` xs
+      = reverse acc : go [] (drop (length pat) xs)
+      | otherwise
+      = go (y : acc) ys

--- a/prettyprinter/src-text/Data/Text/IO.hs
+++ b/prettyprinter/src-text/Data/Text/IO.hs
@@ -1,0 +1,13 @@
+-- Provide a fake API, mimicking Data.Text.IO from text package,
+-- but actually backed by type Text = String. It is used only in rare
+-- circumstances, when prettyprinter is built with -text flag.
+--
+
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Data.Text.IO where
+
+import qualified System.IO
+
+hPutStr = System.IO.hPutStr
+putStrLn = System.IO.putStrLn

--- a/prettyprinter/src-text/Data/Text/Lazy.hs
+++ b/prettyprinter/src-text/Data/Text/Lazy.hs
@@ -1,0 +1,15 @@
+-- Provide a fake API, mimicking Data.Text.Lazy from text package,
+-- but actually backed by type Text = String. It is used only in rare
+-- circumstances, when prettyprinter is built with -text flag.
+--
+
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Data.Text.Lazy where
+
+import Data.Text as T
+
+type Text = T.Text
+length = T.length
+lines = T.lines
+toStrict = id

--- a/prettyprinter/src-text/Data/Text/Lazy/Builder.hs
+++ b/prettyprinter/src-text/Data/Text/Lazy/Builder.hs
@@ -1,0 +1,13 @@
+-- Provide a fake API, mimicking Data.Text.Lazy.Builder from text package,
+-- but actually backed by type Builder = String. It is used only in rare
+-- circumstances, when prettyprinter is built with -text flag.
+--
+
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Data.Text.Lazy.Builder where
+
+type Builder = String
+fromText = id
+singleton = (:[])
+toLazyText = id

--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -339,7 +339,11 @@ instance Pretty Char where
     pretty '\n' = line
     pretty c = Char c
 
+#ifdef MIN_VERSION_text
     prettyList = pretty . (id :: Text -> Text) . fromString
+#else
+    prettyList = vsep . map unsafeTextWithoutNewlines . T.splitOn "\n"
+#endif
 
 -- | Convenience function to convert a 'Show'able value to a 'Doc'. If the
 -- 'String' does not contain newlines, consider using the more performant
@@ -435,6 +439,7 @@ instance Pretty a => Pretty (Maybe a) where
     pretty = maybe mempty pretty
     prettyList = prettyList . catMaybes
 
+#ifdef MIN_VERSION_text
 -- | Automatically converts all newlines to @'line'@.
 --
 -- >>> pretty ("hello\nworld" :: Text)
@@ -451,6 +456,7 @@ instance Pretty Text where pretty = vsep . map unsafeTextWithoutNewlines . T.spl
 
 -- | (lazy 'Text' instance, identical to the strict version)
 instance Pretty Lazy.Text where pretty = pretty . Lazy.toStrict
+#endif
 
 -- | Finding a good example for printing something that does not exist is hard,
 -- so here is an example of printing a list full of nothing.

--- a/prettyprinter/src/Prettyprinter/Render/Text.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Text.hs
@@ -4,8 +4,10 @@
 
 -- | Render an unannotated 'SimpleDocStream' as plain 'Text'.
 module Prettyprinter.Render.Text (
+#ifdef MIN_VERSION_text
     -- * Conversion to plain 'Text'
     renderLazy, renderStrict,
+#endif
 
     -- * Render to a 'Handle'
     renderIO,

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -17,11 +17,7 @@ import           System.Timeout        (timeout)
 
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Internal.Debug
-#ifdef MIN_VERSION_text
 import           Data.Text.Prettyprint.Doc.Render.Text
-#else
-import           Data.Text.Prettyprint.Doc.Render.String
-#endif
 import           Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated)
 
 import Test.QuickCheck.Instances.Text ()
@@ -142,7 +138,7 @@ content = frequency
     [ (1, pure emptyDoc)
     , (10, do word <- choose (minBound, maxBound :: Word8)
               let pgp8Word = toText (BSL.singleton word)
-              pure (pretty (read (show pgp8Word) :: T.Text)) )
+              pure (pretty pgp8Word) )
     , (1, (fmap pretty . elements . mconcat)
               [ ['a'..'z']
               , ['A'..'Z']
@@ -404,8 +400,3 @@ computeRibbonWidthWithFloor
         sdoc = layoutPretty (LayoutOptions (AvailablePerLine 3 0.5)) doc
         expected = SChar 'a' (SLine 0 (SChar 'b' SEmpty))
     in assertEqual "" expected sdoc
-
-#ifndef MIN_VERSION_text
-renderStrict :: SimpleDocStream ann -> String
-renderStrict = renderString
-#endif

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -17,7 +17,11 @@ import           System.Timeout        (timeout)
 
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Internal.Debug
+#ifdef MIN_VERSION_text
 import           Data.Text.Prettyprint.Doc.Render.Text
+#else
+import           Data.Text.Prettyprint.Doc.Render.String
+#endif
 import           Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated)
 
 import Test.QuickCheck.Instances.Text ()
@@ -138,7 +142,7 @@ content = frequency
     [ (1, pure emptyDoc)
     , (10, do word <- choose (minBound, maxBound :: Word8)
               let pgp8Word = toText (BSL.singleton word)
-              pure (pretty pgp8Word) )
+              pure (pretty (read (show pgp8Word) :: T.Text)) )
     , (1, (fmap pretty . elements . mconcat)
               [ ['a'..'z']
               , ['A'..'Z']
@@ -400,3 +404,8 @@ computeRibbonWidthWithFloor
         sdoc = layoutPretty (LayoutOptions (AvailablePerLine 3 0.5)) doc
         expected = SChar 'a' (SLine 0 (SChar 'b' SEmpty))
     in assertEqual "" expected sdoc
+
+#ifndef MIN_VERSION_text
+renderStrict :: SimpleDocStream ann -> String
+renderStrict = renderString
+#endif


### PR DESCRIPTION
I should have raised an issue first, but it is easier to demonstate what I'm proposing with a PR. I'm fine to have it closed/rejected, if we find it unpalatable.

I very much understand that it's a core value of `prettyprinter` to use `Text` and not `String`. However, there are cases when you cannot afford it: namely, when you are a `text` (or `bytestring`) developer ;) or work with a very bleeding-edge GHC. If in future `ansi-wl-pprint` (already deprecated) is to extinct and be replaced by `prettyprinter` in dependencies of `optparse-applicative`, `tasty` and `test-framework`, developers of low-level packages would have to deal with pretty nasty build dependencies. E. g., to run `bytestring` tests you'd have to rebuild `text`, then `prettyprinter`, then `optparse-applicative`, then `tasty` and all its providers. This is extremely disheartening, as I can tell from earlier experience. 

I was interested to check how difficult is to make `prettyprinter` fallback to `String`, if `text` is not available. It seems that just couple of lines and a Cabal flag would suffice. How do you feel about this?