### PR TITLE
Deprecate the Data.Text.Prettyprint.* modules

### DIFF
--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -38,7 +38,7 @@ library
           base          >= 4.5 && < 5
         , ansi-terminal >= 0.4.0
         , text          >= 1.2
-        , prettyprinter >= 1.1.1
+        , prettyprinter >= 1.7.0
 
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat

--- a/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
+++ b/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Terminal" instead.
-module Data.Text.Prettyprint.Doc.Render.Terminal (
+module Data.Text.Prettyprint.Doc.Render.Terminal {-# DEPRECATED "Use \"Prettyprinter.Render.Terminal\" instead." #-} (
     module Prettyprinter.Render.Terminal
 ) where
 

--- a/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Data/Text/Prettyprint/Doc/Render/Terminal/Internal.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Terminal.Internal" instead.
-module Data.Text.Prettyprint.Doc.Render.Terminal.Internal (
+module Data.Text.Prettyprint.Doc.Render.Terminal.Internal {-# DEPRECATED "Use \"Prettyprinter.Render.Terminal.Internal\" instead." #-} (
     module Prettyprinter.Render.Terminal.Internal
 ) where
 

--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
@@ -50,7 +50,7 @@ import qualified System.Console.ANSI    as ANSI
 import           System.IO              (Handle, hPutChar, stdout)
 
 import Prettyprinter
-import Prettyprinter.Util.Panic
+import Prettyprinter.Render.Util.Panic
 
 #if !(SEMIGROUP_MONOID_SUPERCLASS)
 import Data.Semigroup

--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
@@ -49,8 +49,8 @@ import qualified Data.Text.Lazy.Builder as TLB
 import qualified System.Console.ANSI    as ANSI
 import           System.IO              (Handle, hPutChar, stdout)
 
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Util.Panic
+import Prettyprinter
+import Prettyprinter.Util.Panic
 
 #if !(SEMIGROUP_MONOID_SUPERCLASS)
 import Data.Semigroup

--- a/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
+++ b/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
@@ -30,7 +30,7 @@ library
     build-depends:
           base                        >= 4.5 && < 5 && < 5
         , text                        >= 1.2
-        , prettyprinter               >= 1
+        , prettyprinter               >= 1.7.0
         , prettyprinter-ansi-terminal >= 1.1
 
     if !impl(ghc >= 8.0)

--- a/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module Text.PrettyPrint.ANSI.Leijen {-# DEPRECATED "Compatibility module for users of ansi-wl-pprint - use Data.Text.Prettyprint.Doc instead" #-} (
+module Text.PrettyPrint.ANSI.Leijen {-# DEPRECATED "Compatibility module for users of ansi-wl-pprint - use \"Prettyprinter\" instead" #-} (
 
     Doc, putDoc, hPutDoc, empty, char, text, (<>), nest, line, linebreak, group,
     softline, softbreak, hardline, flatAlt, renderSmart, align, hang, indent,
@@ -28,9 +28,9 @@ import Prelude
 import qualified Data.Text.Lazy as TL
 import           System.IO
 
-import           Data.Text.Prettyprint.Doc                 (Pretty (..))
-import qualified Data.Text.Prettyprint.Doc                 as New
-import qualified Data.Text.Prettyprint.Doc.Render.Terminal as NewT
+import           Prettyprinter                 (Pretty (..))
+import qualified Prettyprinter                 as New
+import qualified Prettyprinter.Render.Terminal as NewT
 
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup

--- a/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
+++ b/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
@@ -30,7 +30,7 @@ library
     build-depends:
           base          >= 4.5 && < 5
         , text          >= 1.2
-        , prettyprinter >= 1
+        , prettyprinter >= 1.7.0
 
     if !impl(ghc >= 8.0)
         build-depends: semigroups >= 0.1

--- a/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
+++ b/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module Text.PrettyPrint.Leijen {-# DEPRECATED "Compatibility module for users of wl-pprint - use Data.Text.Prettyprint.Doc instead" #-} (
+module Text.PrettyPrint.Leijen {-# DEPRECATED "Compatibility module for users of wl-pprint - use \"Prettyprinter\" instead" #-} (
 
     Doc, putDoc, hPutDoc, empty, char, text, (<>), nest, line, linebreak, group,
     softline, softbreak, align, hang, indent, encloseSep, list, tupled,
@@ -25,9 +25,9 @@ import Prelude
 import qualified Data.Text.Lazy as TL
 import           System.IO
 
-import           Data.Text.Prettyprint.Doc             (Pretty (..))
-import qualified Data.Text.Prettyprint.Doc             as New
-import qualified Data.Text.Prettyprint.Doc.Render.Text as NewT
+import           Prettyprinter             (Pretty (..))
+import qualified Prettyprinter             as New
+import qualified Prettyprinter.Render.Text as NewT
 
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup

--- a/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
+++ b/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
@@ -31,7 +31,7 @@ library
     build-depends:
           base                        >= 4.5 && < 5
         , text                        >= 1.2
-        , prettyprinter               >= 1
+        , prettyprinter               >= 1.7.0
         , prettyprinter-ansi-terminal >= 1.1.1
         , ansi-wl-pprint              >= 0.6.8
         , ansi-terminal

--- a/prettyprinter-convert-ansi-wl-pprint/src/Data/Text/Prettyprint/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Data/Text/Prettyprint/Convert/AnsiWlPprint.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Convert.AnsiWlPprint" instead.
-module Data.Text.Prettyprint.Convert.AnsiWlPprint (
+module Data.Text.Prettyprint.Convert.AnsiWlPprint {-# DEPRECATED "Use \"Prettyprinter.Convert.AnsiWlPprint\" instead." #-} (
     module Prettyprinter.Convert.AnsiWlPprint
 ) where
 

--- a/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
@@ -23,10 +23,10 @@ module Prettyprinter.Convert.AnsiWlPprint (
 
 import qualified Data.Text as T
 
-import qualified Data.Text.Prettyprint.Doc.Internal                 as New
-import qualified Data.Text.Prettyprint.Doc.Render.Terminal.Internal as NewTerm
-import qualified System.Console.ANSI                                as Ansi
-import qualified Text.PrettyPrint.ANSI.Leijen.Internal              as Old
+import qualified Prettyprinter.Doc.Internal            as New
+import qualified Prettyprinter.Terminal.Internal       as NewTerm
+import qualified System.Console.ANSI                   as Ansi
+import qualified Text.PrettyPrint.ANSI.Leijen.Internal as Old
 
 
 

--- a/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
@@ -23,10 +23,10 @@ module Prettyprinter.Convert.AnsiWlPprint (
 
 import qualified Data.Text as T
 
-import qualified Prettyprinter.Doc.Internal            as New
-import qualified Prettyprinter.Terminal.Internal       as NewTerm
-import qualified System.Console.ANSI                   as Ansi
-import qualified Text.PrettyPrint.ANSI.Leijen.Internal as Old
+import qualified Prettyprinter.Doc.Internal             as New
+import qualified Prettyprinter.Render.Terminal.Internal as NewTerm
+import qualified System.Console.ANSI                    as Ansi
+import qualified Text.PrettyPrint.ANSI.Leijen.Internal  as Old
 
 
 

--- a/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
@@ -23,7 +23,7 @@ module Prettyprinter.Convert.AnsiWlPprint (
 
 import qualified Data.Text as T
 
-import qualified Prettyprinter.Doc.Internal             as New
+import qualified Prettyprinter.Internal                 as New
 import qualified Prettyprinter.Render.Terminal.Internal as NewTerm
 import qualified System.Console.ANSI                    as Ansi
 import qualified Text.PrettyPrint.ANSI.Leijen.Internal  as Old

--- a/prettyprinter/app/GenerateReadme.hs
+++ b/prettyprinter/app/GenerateReadme.hs
@@ -11,8 +11,8 @@ import qualified Data.List                             as L
 import           Data.Text                             (Text)
 import qualified Data.Text                             as T
 import qualified Data.Text.IO                          as T
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Render.Text
+import           Prettyprinter
+import           Prettyprinter.Render.Text
 
 import MultilineTh
 

--- a/prettyprinter/bench/FasterUnsafeText.hs
+++ b/prettyprinter/bench/FasterUnsafeText.hs
@@ -6,9 +6,9 @@ module Main (main) where
 
 import           Gauge.Main
 import           Data.Char
-import           Data.Text                          (Text)
-import qualified Data.Text                          as T
-import           Data.Text.Prettyprint.Doc.Internal
+import           Data.Text              (Text)
+import qualified Data.Text              as T
+import           Prettyprinter.Internal
 
 
 

--- a/prettyprinter/bench/Fusion.hs
+++ b/prettyprinter/bench/Fusion.hs
@@ -14,9 +14,9 @@ import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           System.Random
 
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Render.Text
-import qualified Text.PrettyPrint.ANSI.Leijen          as WL
+import           Prettyprinter
+import           Prettyprinter.Render.Text
+import qualified Text.PrettyPrint.ANSI.Leijen as WL
 
 #if !(APPLICATIVE_MONAD)
 import Control.Applicative

--- a/prettyprinter/bench/LargeOutput.hs
+++ b/prettyprinter/bench/LargeOutput.hs
@@ -18,8 +18,8 @@ import           Data.Text                             (Text)
 import qualified Data.Text                             as T
 import qualified Data.Text.IO                          as T
 import qualified Data.Text.Lazy                        as TL
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Render.Text
+import           Prettyprinter
+import           Prettyprinter.Render.Text
 import           GHC.Generics
 import           Test.QuickCheck
 import           Test.QuickCheck.Gen

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter" instead.
-module Data.Text.Prettyprint.Doc (
+module Data.Text.Prettyprint.Doc {-# DEPRECATED "Use \"Prettyprinter\" instead." #-} (
     module Prettyprinter
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Internal" instead.
-module Data.Text.Prettyprint.Doc.Internal (
+module Data.Text.Prettyprint.Doc.Internal {-# DEPRECATED "Use \"Prettyprinter.Internal\" instead." #-} (
     module Prettyprinter.Internal
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal/Debug.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal/Debug.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Internal.Debug" instead.
-module Data.Text.Prettyprint.Doc.Internal.Debug (
+module Data.Text.Prettyprint.Doc.Internal.Debug {-# DEPRECATED "Use \"Prettyprinter.Internal.Debug\" instead." #-} (
     module Prettyprinter.Internal.Debug
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal/Type.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Internal/Type.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Internal.Type" instead.
-module Data.Text.Prettyprint.Doc.Internal.Type (
+module Data.Text.Prettyprint.Doc.Internal.Type {-# DEPRECATED "Use \"Prettyprinter.Internal.Type\" instead." #-} (
     module Prettyprinter.Internal.Type
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/String.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/String.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.String" instead.
-module Data.Text.Prettyprint.Doc.Render.String (
+module Data.Text.Prettyprint.Doc.Render.String {-# DEPRECATED "Use \"Prettyprinter.Render.String\" instead." #-} (
     module Prettyprinter.Render.String
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Text.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Text.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Text" instead.
-module Data.Text.Prettyprint.Doc.Render.Text (
+module Data.Text.Prettyprint.Doc.Render.Text {-# DEPRECATED "Use \"Prettyprinter.Render.Text\" instead." #-} (
     module Prettyprinter.Render.Text
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/StackMachineTutorial.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/StackMachineTutorial.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Tutorials.StackMachineTutorial" instead.
-module Data.Text.Prettyprint.Doc.Render.Tutorials.StackMachineTutorial (
+module Data.Text.Prettyprint.Doc.Render.Tutorials.StackMachineTutorial {-# DEPRECATED "Use \"Prettyprinter.Render.Tutorials.StackMachineTutorial\" instead." #-} (
     module Prettyprinter.Render.Tutorials.StackMachineTutorial
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/TreeRenderingTutorial.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Tutorials/TreeRenderingTutorial.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Tutorials.TreeRenderingTutorial" instead.
-module Data.Text.Prettyprint.Doc.Render.Tutorials.TreeRenderingTutorial (
+module Data.Text.Prettyprint.Doc.Render.Tutorials.TreeRenderingTutorial {-# DEPRECATED "Use \"Prettyprinter.Render.Tutorials.TreeRenderingTutorial\" instead." #-} (
     module Prettyprinter.Render.Tutorials.TreeRenderingTutorial
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/Panic.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/Panic.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Util.Panic" instead.
-module Data.Text.Prettyprint.Doc.Render.Util.Panic (
+module Data.Text.Prettyprint.Doc.Render.Util.Panic {-# DEPRECATED "Use \"Prettyprinter.Render.Util.Panic\" instead." #-} (
     module Prettyprinter.Render.Util.Panic
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/SimpleDocTree.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Util.SimpleDocTree" instead.
-module Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree (
+module Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree {-# DEPRECATED "Use \"Prettyprinter.Render.Util.SimpleDocTree\" instead." #-} (
     module Prettyprinter.Render.Util.SimpleDocTree
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Render.Util.StackMachine" instead.
-module Data.Text.Prettyprint.Doc.Render.Util.StackMachine (
+module Data.Text.Prettyprint.Doc.Render.Util.StackMachine {-# DEPRECATED "Use \"Prettyprinter.Render.Util.StackMachine\" instead." #-} (
     module Prettyprinter.Render.Util.StackMachine
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Symbols.Ascii" instead.
-module Data.Text.Prettyprint.Doc.Symbols.Ascii (
+module Data.Text.Prettyprint.Doc.Symbols.Ascii {-# DEPRECATED "Use \"Prettyprinter.Symbols.Ascii\" instead." #-} (
     module Prettyprinter.Symbols.Ascii
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Symbols/Unicode.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Symbols.Unicode" instead.
-module Data.Text.Prettyprint.Doc.Symbols.Unicode (
+module Data.Text.Prettyprint.Doc.Symbols.Unicode {-# DEPRECATED "Use \"Prettyprinter.Symbols.Unicode\" instead." #-} (
     module Prettyprinter.Symbols.Unicode
 ) where
 

--- a/prettyprinter/src/Data/Text/Prettyprint/Doc/Util.hs
+++ b/prettyprinter/src/Data/Text/Prettyprint/Doc/Util.hs
@@ -1,11 +1,4 @@
--- | This module is part of the old @Data.Text.Prettyprint.Doc@ module hierarchy
--- which is being replaced by a shallower @Prettyprinter@ module hierarchy
--- offering the same API.
---
--- This module will be deprecated and eventually removed.
---
--- Use "Prettyprinter.Util" instead.
-module Data.Text.Prettyprint.Doc.Util (
+module Data.Text.Prettyprint.Doc.Util {-# DEPRECATED "Use \"Prettyprinter.Util\" instead." #-} (
     module Prettyprinter.Util
 ) where
 

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -15,10 +15,10 @@ import           Data.Text.PgpWordlist
 import           Data.Word
 import           System.Timeout        (timeout)
 
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Internal.Debug
-import           Data.Text.Prettyprint.Doc.Render.Text
-import           Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated)
+import           Prettyprinter
+import           Prettyprinter.Internal.Debug
+import           Prettyprinter.Render.Text
+import           Prettyprinter.Render.Util.StackMachine (renderSimplyDecorated)
 
 import Test.QuickCheck.Instances.Text ()
 import Test.Tasty

--- a/prettyprinter/test/Testsuite/StripTrailingSpace.hs
+++ b/prettyprinter/test/Testsuite/StripTrailingSpace.hs
@@ -10,8 +10,8 @@ module StripTrailingSpace (testStripTrailingSpace) where
 import           Data.Text (Text)
 import qualified Data.Text as T
 
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Util.StackMachine
+import Prettyprinter
+import Prettyprinter.Render.Util.StackMachine
 
 import Test.Tasty
 import Test.Tasty.HUnit


### PR DESCRIPTION
Context: #110 

TODO:

* [x] Replace imports of old modules
* [ ] ~~Implement this recommendation: https://github.com/quchen/prettyprinter/issues/110#issuecomment-667991894~~
* [x] Adjust version bounds