### PR TITLE
Fix no-text CI with GHC 7.10.3

### DIFF
--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Build
       # -optl-no-pie is a workaround for an issue with GHC 7.10.3:
       # https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/123
-      run: cabal build --ghc-option=-optl-no-pie --ghc-option=-optc-no-pie -f-text prettyprinter:prettyprinter
+      run: cabal build --ghc-option=-optl-no-pie -f-text prettyprinter:prettyprinter

--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -33,4 +33,6 @@ jobs:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Build
-      run: cabal build -f-text prettyprinter:prettyprinter
+      # -optl-no-pie is a workaround for an issue with GHC 7.10.3:
+      # https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/123
+      run: cabal build --ghc-option=-optl-no-pie -f-text prettyprinter:prettyprinter

--- a/.github/workflows/no-text.yml
+++ b/.github/workflows/no-text.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Build
       # -optl-no-pie is a workaround for an issue with GHC 7.10.3:
       # https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/123
-      run: cabal build --ghc-option=-optl-no-pie -f-text prettyprinter:prettyprinter
+      run: cabal build --ghc-option=-optl-no-pie --ghc-option=-optc-no-pie -f-text prettyprinter:prettyprinter


### PR DESCRIPTION
This job was reporting linker issues due to
https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/123.