### PR TITLE
Add pattern SString

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,3 +8,7 @@ packages: prettyprinter
         , prettyprinter-compat-annotated-wl-pprint
 tests: true
 benchmarks: true
+
+source-repository-package
+  type: git
+  location: https://github.com/Bodigrim/linear-builder

--- a/prettyprinter/bench/LargeOutput.hs
+++ b/prettyprinter/bench/LargeOutput.hs
@@ -179,12 +179,12 @@ randomProgram seed size = let MkGen gen = arbitrary in gen (mkQCGen seed) size
 main :: IO ()
 main = do
     let prog = randomProgram 1 60
-        renderedProg = (renderLazy . layoutPretty defaultLayoutOptions { layoutPageWidth = Unbounded } . pretty) prog
-        (progLines, progWidth) = let l = TL.lines renderedProg in (length l, maximum (map TL.length l))
+        renderedProg = (renderStrict . layoutPretty defaultLayoutOptions { layoutPageWidth = Unbounded } . pretty) prog
+        (progLines, progWidth) = let l = T.lines renderedProg in (length l, maximum (map T.length l))
     putDoc ("Program size:" <+> pretty progLines <+> "lines, maximum width:" <+> pretty progWidth)
 
-    let renderWith :: (Doc ann -> SimpleDocStream ann) -> Program -> TL.Text
-        renderWith f = renderLazy . f . pretty
+    let renderWith :: (Doc ann -> SimpleDocStream ann) -> Program -> T.Text
+        renderWith f = renderStrict . f . pretty
 
     let _80ColumnsLayoutOptions = defaultLayoutOptions { layoutPageWidth = AvailablePerLine 80 0.5 }
         unboundedLayoutOptions  = defaultLayoutOptions { layoutPageWidth = Unbounded }

--- a/prettyprinter/bench/LargeOutput.hs
+++ b/prettyprinter/bench/LargeOutput.hs
@@ -193,17 +193,13 @@ main = do
 
     defaultMain
         [ bgroup "80 characters, 50% ribbon"
-            [ bgroup "prettyprinter"
-                [ bench "layoutPretty"  (nf (renderWith (layoutPretty _80ColumnsLayoutOptions)) prog)
-                , bench "layoutSmart"   (nf (renderWith (layoutSmart  _80ColumnsLayoutOptions)) prog)
-                , bench "layoutCompact" (nf (renderWith layoutCompact                         ) prog)
-                ]
-            , bench "ansi-wl-pprint" (nf (($ "") . WL.displayS . WL.renderPretty 0.5 80 . WL.pretty) prog) ]
+            [ bench "layoutPretty"  (nf (renderWith (layoutPretty _80ColumnsLayoutOptions)) prog)
+            , bench "layoutSmart"   (nf (renderWith (layoutSmart  _80ColumnsLayoutOptions)) prog)
+            , bench "layoutCompact" (nf (renderWith layoutCompact                         ) prog)
+            ]
         , bgroup "Infinite/large page width"
-            [ bgroup "prettyprinter"
-                [ bench "layoutPretty"  (nf (renderWith (layoutPretty unboundedLayoutOptions)) prog)
-                , bench "layoutSmart"   (nf (renderWith (layoutSmart  unboundedLayoutOptions)) prog)
-                , bench "layoutCompact" (nf (renderWith layoutCompact                        ) prog)
-                ]
-            , bench "ansi-wl-pprint" (nf (($ "") . WL.displayS . WL.renderPretty 1 (fromIntegral progWidth + 10) . WL.pretty) prog) ]
+            [ bench "layoutPretty"  (nf (renderWith (layoutPretty unboundedLayoutOptions)) prog)
+            , bench "layoutSmart"   (nf (renderWith (layoutSmart  unboundedLayoutOptions)) prog)
+            , bench "layoutCompact" (nf (renderWith layoutCompact                        ) prog)
+            ]
         ]

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -68,7 +68,8 @@ library
         , ScopedTypeVariables
 
     build-depends:
-          base >= 4.5 && < 5
+          base >= 4.5 && < 5,
+          text-builder-linear
 
     if flag(text)
         build-depends: text >= 1.2

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -170,6 +170,7 @@ test-suite testsuite
 
 
 benchmark fusion
+    buildable: False
     type: exitcode-stdio-1.0
     hs-source-dirs: bench
     main-is: Fusion.hs
@@ -191,6 +192,7 @@ benchmark fusion
         buildable: False
 
 benchmark faster-unsafe-text
+    buildable: False
     build-depends:
           base >= 4.5 && < 5
         , prettyprinter


### PR DESCRIPTION
I wonder if this could provide a lightweight resolution to #207, alternative to #208. @newhoggy what do you think? 

The idea is to use `SString` to perform `T.pack` / `T.unpack` when on GHC 7.10+ (which covers the vast majority of users) and resort to slow `read . show` (https://github.com/quchen/prettyprinter/issues/207#issuecomment-928422424) only on older systems. 