### PR TITLE
Solving Windows building crash caused by symbols `»` and `«` in Deprecated pragma

### DIFF
--- a/prettyprinter/src/Prettyprinter/Render/Tutorials/StackMachineTutorial.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Tutorials/StackMachineTutorial.hs
@@ -17,7 +17,7 @@
 -- The module is written to be readable top-to-bottom in both Haddock and raw
 -- source form.
 module Prettyprinter.Render.Tutorials.StackMachineTutorial
-    {-# DEPRECATED "Writing your own stack machine is probably more efficient and customizable; also consider using »renderSimplyDecorated(A)« instead" #-}
+    {-# DEPRECATED "Writing your own stack machine is probably more efficient and customizable; also consider using renderSimplyDecorated(A) instead" #-}
     where
 
 import qualified Data.Text.Lazy         as TL


### PR DESCRIPTION
I've been trying to build `prettyprinter` as `dhall` dependency on Windows 11 and got an error `commitAndReleaseBuffer: invalid argument (invalid character)` while printing deprecated pragma text from module `Prettyprinter.Render.Tutorials.StackMachineTutorial`

```haskell
module Prettyprinter.Render.Tutorials.StackMachineTutorial
    {-# DEPRECATED "Writing your own stack machine is probably more efficient and customizable; also consider using »renderSimplyDecorated(A)« instead" #-}
    where
```

After changing locale to ASCII via
```
chcp 437
```
problem was solved, but it was hard to understand what's going on. I haven't tried to locate problem by deleting this symbols and trying to build fork but I can't see another possible reasons for this error