### PR TITLE
Add better color support

### DIFF
--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -36,7 +36,8 @@ library
 
     build-depends:
           base          >= 4.5 && < 5
-        , ansi-terminal >= 0.4.0
+        , ansi-terminal >= 0.9.0
+        , colour        >= 2.1.0
         , text          >= 1.2
         , prettyprinter >= 1.7.0
 

--- a/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
+++ b/prettyprinter-convert-ansi-wl-pprint/src/Prettyprinter/Convert/AnsiWlPprint.hs
@@ -110,17 +110,17 @@ toAnsiWlPprint = \doc -> case doc of
       where
         convertFg, convertBg, convertBold, convertUnderlining :: Old.Doc -> Old.Doc
         convertFg = case NewTerm.ansiForeground style of
-            Nothing -> id
-            Just (intensity, color) -> convertColor True intensity color
+            Just (NewTerm.Color16 intensity color) -> convertColor True intensity color
+            _ -> id
         convertBg = case NewTerm.ansiBackground style of
-            Nothing -> id
-            Just (intensity, color) -> convertColor False intensity color
+            Just (NewTerm.Color16 intensity color) -> convertColor False intensity color
+            _ -> id
         convertBold = case NewTerm.ansiBold style of
-            Nothing -> id
             Just NewTerm.Bold -> Old.bold
+            _ -> id
         convertUnderlining = case NewTerm.ansiUnderlining style of
-            Nothing -> id
             Just NewTerm.Underlined -> Old.underline
+            _ -> id
 
         convertColor
             :: Bool -- True = foreground, False = background


### PR DESCRIPTION
Followup to (https://github.com/quchen/prettyprinter/issues/65)

For background, I hope to replace the current ad-hoc style module used by Chapelure (https://hackage.haskell.org/package/chapelure-0.0.1.0/docs/Chapelure-Style.html)

# Notes:
* Added an `AnsiColor` type with three constructors: `Color16`, `ColorPalette` (maybe it should be `ColorPaletted`?) , and `ColorRGB`
* To support `ColorRGB`, we need a dependency on the `colour` package, and we need to bump the version of `ansi-terminal` we depend on 0.4 → 0.9
* I also added `DoubleUnderlined` to type `Underlined` and `Faint` to type `Bold`, for completeness to support these ansi-terminal features. Both are 'not widely supported', according to ansi-terminal, so whether to include them is debatable. But we *do* support `Italicized`, which is labelled the same
* I added an extra style marker, 'Inverted', to support the `SetSwapForegroundBackground` of `ansi-terminal`, which *is* widely-supported. There's also `SetBlinkSpeed` and `SetVisible`, should we support those too?
# Some observations on the library
* Is there a reason we define the types `Color` and `Intensity` ourselves rather than using and reexporting the identical versions from `System.Console.ANSI.Types`?
  * Similarly, we could re-use `ConsoleIntensity` and `Underlining` instead of `Bold` and `Underlined`, but that introduces an explicit 'None' value that might be confusing (https://github.com/quchen/prettyprinter/issues/42). Or we could replace Maybe Bold → ConsoleIntensity in AnsiStyle. I took the first approach in Chapelure.Style 
* The `prettyprinter-convert-ansi-wl-pprint` converter has been updated, and it drops all of the new styles, like it did for italics
* I couldn't get the doctests for `prettyprinter-ansi-terminal` to work: I get several errors of the form "Could not find module ‘System.Console.ANSI’" etc