### PR TITLE
Add underline styling and hyperlinking support

### DIFF
--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -39,6 +39,8 @@ library
         , ansi-terminal >= 0.4.0
         , text          >= 1.2
         , prettyprinter >= 1.7.0
+        , containers    >= 0.6
+        , colour        >= 2
 
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat


### PR DESCRIPTION
This could be much simplified if `ansi-terminal` had better support for underline styles and colours.

(Needs squashing)