### PR TITLE
Change layout function called for renderPretty in ansi-wl-pprint compat

### DIFF
--- a/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
@@ -230,7 +230,7 @@ rational = New.pretty . show
 
 renderPretty :: Float -> Int -> Doc -> SimpleDoc
 renderPretty ribbonFraction pageWidth
-    = New.layoutSmart New.LayoutOptions
+    = New.layoutPretty New.LayoutOptions
         { New.layoutPageWidth = New.AvailablePerLine pageWidth (realToFrac ribbonFraction) }
 
 


### PR DESCRIPTION
Layout smart is more expensive, and can potentially hang in situations
where layout pretty works fine.
