### PR TITLE
Fix newline escaping in haddock for `Pretty Char` instance

### DIFF
--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -330,7 +330,7 @@ instance Pretty Bool where
     pretty True  = "True"
     pretty False = "False"
 
--- | Instead of @('pretty' '\n')@, consider using @'line'@ as a more readable
+-- | Instead of @('pretty' '\\n')@, consider using @'line'@ as a more readable
 -- alternative.
 --
 -- >>> pretty 'f' <> pretty 'o' <> pretty 'o'


### PR DESCRIPTION
Current haddock:
![image](https://github.com/user-attachments/assets/2f624cc0-969d-4a35-b7b7-322cab4fc4b7)

with the fix:
![image](https://github.com/user-attachments/assets/ab05961b-ef1f-4085-9f90-203d2953d963)
