### PR TITLE
Add support for "faint" intensity

### DIFF
--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal.hs
@@ -11,7 +11,7 @@ module Prettyprinter.Render.Terminal (
     bgColor, bgColorDull,
 
     -- ** Font style
-    bold, italicized, underlined,
+    bold, italicized, underlined, faint,
 
     -- ** Internal markers
     --


### PR DESCRIPTION
The "faint" console intensity (`\ESC[2m`) makes for a nice dim color and
is useful for rendering comments or other, less important text.

For example, the body of the PR being created by my script here:

![](https://files.pbrisbin.com/screenshots/screenshot.1675716.png)

The `ansi-terminal-types` documentation says it is "not widely
supported"[^1], which may be why it's not supported here yet, but I've
found other sources that say the same thing of italics[^2]. Besides,
folks can simply choose not to use.

[^1]: https://hackage-content.haskell.org/package/ansi-terminal-types-1.1.3/docs/System-Console-ANSI-Types.html#t:ConsoleIntensity
[^2]: https://stackoverflow.com/a/33206814
