### PR TITLE
Fix inconsistency betweeen ansi-terminal's renderLazy/renderIO

### DIFF
--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
@@ -160,7 +160,7 @@ renderLazy =
             SAnnPush style rest ->
                 let currentStyle = unsafePeek s
                     newStyle = style <> currentStyle
-                in  TLB.fromText (styleToRawText newStyle) <> go (push style s) rest
+                in  TLB.fromText (styleToRawText newStyle) <> go (push newStyle s) rest
             SAnnPop rest ->
                 let (_currentStyle, s') = unsafePop s
                     newStyle = unsafePeek s'


### PR DESCRIPTION
These two render differently:
```haskell
import Prettyprinter
import Prettyprinter.Render.Terminal
import System.IO
import qualified Data.Text.IO as T
let doc = annotate (color Red) (pretty '1' <> annotate bold (pretty '2' <> annotate (bgColor Magenta) (pretty '3')))
renderIO stdout . layoutPretty defaultLayoutOptions  $ doc
T.putStr . renderStrict . layoutPretty defaultLayoutOptions $ doc
```

e.g. here you can see that renderStrict is losing the outermost formatting of `annotate (color Red)` from the example above, but renderIO works correctly.
<img width="585" height="67" alt="Screenshot 2025-10-27 at 19 12 10" src="https://github.com/user-attachments/assets/6a9da4b1-a3d2-4af4-a445-e36be814672c" />

This was trivial to fix, we just need to pass the updated `newStyle` instead of the old `style`. After this change both render identically:
<img width="586" height="66" alt="Screenshot 2025-10-27 at 19 11 13" src="https://github.com/user-attachments/assets/2d605963-e823-46c7-8095-f686cb2fea90" />

This matches the logic used in `renderIO`.

