### PR TITLE
Alternative fix for #205

### DIFF
--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -1895,6 +1895,7 @@ layoutPretty
     -> SimpleDocStream ann
 layoutPretty (LayoutOptions pageWidth_@(AvailablePerLine lineLength ribbonFraction)) =
     layoutWadlerLeijen
+        smartLine
         (FittingPredicate
              (\lineIndent currentColumn _initialIndentY sdoc ->
                  fits
@@ -1982,7 +1983,8 @@ layoutSmart
     -> Doc ann
     -> SimpleDocStream ann
 layoutSmart (LayoutOptions pageWidth_@(AvailablePerLine lineLength ribbonFraction)) =
-    layoutWadlerLeijen (FittingPredicate fits) pageWidth_
+    dropIndentationOnEmptyLines .
+        layoutWadlerLeijen plainLine (FittingPredicate fits) pageWidth_
   where
     -- Why doesn't layoutSmart simply check the entire document?
     --
@@ -2001,7 +2003,14 @@ layoutSmart (LayoutOptions pageWidth_@(AvailablePerLine lineLength ribbonFractio
         go w (SChar _ x)        = go (w - 1) x
         go w (SText l _t x)     = go (w - l) x
         go _ (SLine i x)
-          | minNestingLevel < i = go (lineLength - i) x -- TODO: Take ribbon width into account?! (#142)
+          | minNestingLevel < i =
+              let i' = case x of
+                        SEmpty  -> 0
+                        SLine{} -> 0
+                        _       -> i
+              in if minNestingLevel < i'
+                    then go (lineLength - i') x -- TODO: Take ribbon width into account?! (#142)
+                    else True
           | otherwise           = True
         go w (SAnnPush _ x)     = go w x
         go w (SAnnPop x)        = go w x
@@ -2029,6 +2038,7 @@ layoutSmart (LayoutOptions Unbounded) = layoutUnbounded
 layoutUnbounded :: Doc ann -> SimpleDocStream ann
 layoutUnbounded =
     layoutWadlerLeijen
+        smartLine
         (FittingPredicate
             (\_lineIndent _currentColumn _initialIndentY sdoc -> not (failsOnFirstLine sdoc)))
         Unbounded
@@ -2046,13 +2056,45 @@ layoutUnbounded =
             SAnnPush _ s -> go s
             SAnnPop s    -> go s
 
+plainLine :: Int -> SimpleDocStream ann -> SimpleDocStream ann
+plainLine i x = SLine i x
+
+smartLine :: Int -> SimpleDocStream ann -> SimpleDocStream ann
+smartLine i x =
+    let i' = case x of
+            SEmpty  -> 0
+            SLine{} -> 0
+            _       -> i
+    in SLine i' x
+
+-- | Remove indentation that would otherwise survive on empty lines.
+dropIndentationOnEmptyLines :: SimpleDocStream ann -> SimpleDocStream ann
+dropIndentationOnEmptyLines = go
+  where
+    go sds = case sds of
+        SFail          -> SFail
+        SEmpty         -> SEmpty
+        SChar c x      -> SChar c (go x)
+        SText l t x    -> SText l t (go x)
+        SLine i x      ->
+            let x' = go x
+                i' = case x' of
+                    SEmpty  -> 0
+                    SLine{} -> 0
+                    _       -> i
+            in SLine i' x'
+        SAnnPush ann x -> SAnnPush ann (go x)
+        SAnnPop x      -> SAnnPop (go x)
+
 -- | The Wadler/Leijen layout algorithm
 layoutWadlerLeijen
-    :: forall ann. FittingPredicate ann
+    :: forall ann. (Int -> SimpleDocStream ann -> SimpleDocStream ann)
+    -> FittingPredicate ann
     -> PageWidth
     -> Doc ann
     -> SimpleDocStream ann
 layoutWadlerLeijen
+    mkLine
     (FittingPredicate fits)
     pageWidth_
     doc
@@ -2073,15 +2115,7 @@ layoutWadlerLeijen
         Empty           -> best nl cc ds
         Char c          -> let !cc' = cc+1 in SChar c (best nl cc' ds)
         Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
-        Line            -> let x = best i i ds
-                               -- Don't produce indentation if there's no
-                               -- following text on the same line.
-                               -- This prevents trailing whitespace.
-                               i' = case x of
-                                   SEmpty  -> 0
-                                   SLine{} -> 0
-                                   _       -> i
-                           in SLine i' x
+        Line            -> mkLine i (best i i ds)
         FlatAlt x _     -> best nl cc (Cons i x ds)
         Cat x y         -> best nl cc (Cons i x (Cons i y ds))
         Nest j x        -> let !ij = i+j in best nl cc (Cons ij x ds)

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -53,6 +53,8 @@ tests = testGroup "Tests"
                    groupingPerformance
         , testCase "fillSep performance"
                    fillSepPerformance
+        , testCase "Issue 205"
+                   issue205
         ]
     , testGroup "Regression tests"
         [ testCase "layoutSmart: softline behaves like a newline (#49)"
@@ -284,6 +286,14 @@ fillSepPerformance = docPerformanceTest (pathological 1000)
   where
     pathological :: Int -> Doc ann
     pathological n = iterate (\x -> fillSep ["a", x <+> "b"] ) "foobar" !! n
+
+issue205 :: Assertion
+issue205 = do
+    let doc = fillSep (replicate 30 (sep ["abc", "xyz" :: Doc ()]))
+        t = renderStrict (layoutSmart defaultLayoutOptions doc)
+    timeout 1000000 (evaluate t) >>= \t' -> case t' of
+      Nothing -> assertFailure "Timeout!"
+      Just _success -> pure ()
 
 regressionLayoutSmartSoftline :: Assertion
 regressionLayoutSmartSoftline


### PR DESCRIPTION
I asked Codex to come up with an alternative to #282 for fixing #205.

I haven't looked at it very closely myself yet.

Notes from Codex:

```
• Findings

  - #205 is not caused by the strict Int in SLine at prettyprinter/src/Prettyprinter/
    Internal.hs:1669. The real problem is the eager case x of ... in the Line branch at
    prettyprinter/src/Prettyprinter/Internal.hs:2076, because that forces the tail stream
    while layoutSmart is still exploring alternatives.
  - That also explains why only layoutSmart blows up: its fits predicate keeps walking across
    multiple SLines at prettyprinter/src/Prettyprinter/Internal.hs:1995, while layoutPretty
    stops at the first line break.
  - I checked the old sjakobi/issue205 work:
      - a61681e = “Remove bang on Int in SLine”
      - ee48764 = revert of that change
      - 2a18909 = full revert of #139
  - Bench result with the exact issue reproducer, built -O2 with ghc-9.12.2:
      - current master: n=30 -> 8.55s, n=33 -> timed out at 20s
      - lazy-SLine variant: n=30 -> 8.66s, n=33 -> timed out at 20s
      - full revert of #139: effectively instant
  - So the “make the Int lazy” idea is dead: same asymptotics, same runtime.

  Best Candidate

  I prototyped a targeted fix in /tmp/pp-master-detached/prettyprinter/src/Prettyprinter/
  Internal.hs:1981 without touching your main checkout:

  - build layoutSmart with plain SLine i x again
  - add a linear post-pass dropIndentationOnEmptyLines that only rewrites SLine i x to SLine 0
    x when the transformed tail starts with SEmpty or another SLine
  - keep layoutPretty and layoutUnbounded on the current behavior
  - in layoutSmart.fits, only normalize blank-line indentation in the branch that was already
    going to recurse

  That prototype:

  - fixes #205 immediately: n=30, 33, 40 all measured 0.00s
  - preserves the #139 behavior
  - avoids the overreach of removeTrailingWhitespace postprocessing
  - passes the full testsuite via cabal test prettyprinter:testsuite --with-compiler=ghc-9.12

  Other Options

  - Full revert of #139: simplest, but reintroduces the old trailing-indentation regression.
  - removeTrailingWhitespace after layoutSmart: fast and easy, but too aggressive; it strips
    user-produced trailing spaces too.
  - New SimpleDocStream constructor for deferred indentation: probably the cleanest long-term
    design, but much more invasive.
```