### PR TITLE
Remove compatibility code for GHC < 8

### DIFF
--- a/misc/version-compatibility-macros.h
+++ b/misc/version-compatibility-macros.h
@@ -8,13 +8,9 @@
 -- These macros allow writing CPP compatibility hacks in a way that makes their
 -- purpose much clearer than just demanding a specific version of a library.
 
-#define APPLICATIVE_MONAD               MIN_VERSION_base(4,8,0)
-#define FOLDABLE_TRAVERSABLE_IN_PRELUDE (MIN_VERSION_base(4,8,0) && !defined(__MHS__))
-#define FUNCTOR_IDENTITY_IN_BASE        MIN_VERSION_base(4,8,0)
-#define MONOID_IN_PRELUDE               MIN_VERSION_base(4,8,0)
-#define NATURAL_IN_BASE                 MIN_VERSION_base(4,8,0)
+#define FOLDABLE_TRAVERSABLE_IN_PRELUDE !defined(__MHS__)
 
-#define SEMIGROUP_IN_BASE               MIN_VERSION_base(4,9,0)
+#define LIFTA2_IN_PRELUDE               MIN_VERSION_base(4,18,0)
 
 #define SEMIGROUP_MONOID_SUPERCLASS     MIN_VERSION_base(4,11,0)
 

--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -34,7 +34,7 @@ library
                     , Data.Text.Prettyprint.Doc.Render.Terminal.Internal
                     , Prettyprinter.Render.Terminal
                     , Prettyprinter.Render.Terminal.Internal
-    ghc-options:      -Wall -O2
+    ghc-options:      -Wall -O2 -Wcompat
     hs-source-dirs:   src
     include-dirs:     misc
     default-language: Haskell2010
@@ -58,11 +58,6 @@ library
             , Data.Text.Lazy
             , Data.Text.Lazy.Builder
 
-    if impl(ghc >= 8.0)
-        ghc-options: -Wcompat
-    if !impl(ghc >= 8.0) && !impl(mhs)
-        build-depends: semigroups >= 0.1
-
 test-suite doctest
     type: exitcode-stdio-1.0
     hs-source-dirs: test/Doctest
@@ -72,9 +67,6 @@ test-suite doctest
         , doctest >= 0.9
     ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
     default-language: Haskell2010
-    if impl (ghc < 7.10)
-        buildable: False
-        -- Doctest cannot search folders in old versions it seems :-(
 
 benchmark large-output
     build-depends:
@@ -93,7 +85,3 @@ benchmark large-output
     ghc-options:         -O2 -rtsopts -Wall
     default-language:    Haskell2010
     type:                exitcode-stdio-1.0
-
-    -- For GHC.Generics
-    if !impl(ghc >= 7.6)
-        build-depends: ghc-prim

--- a/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
+++ b/prettyprinter-ansi-terminal/src/Prettyprinter/Render/Terminal/Internal.hs
@@ -53,15 +53,7 @@ import Prettyprinter
 import Prettyprinter.Render.Util.Panic
 
 #if !(SEMIGROUP_MONOID_SUPERCLASS)
-import Data.Semigroup
-#endif
-
-#if !(MIN_VERSION_base(4,6,0))
-modifyIORef' :: IORef a -> (a -> a) -> IO ()
-modifyIORef' ref f = do
-    x <- readIORef ref
-    let x' = f x
-    x' `seq` writeIORef ref x'
+import Data.Semigroup (Semigroup(..))
 #endif
 
 -- $setup

--- a/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
+++ b/prettyprinter-compat-annotated-wl-pprint/src/Text/PrettyPrint/Annotated/Leijen.hs
@@ -17,17 +17,12 @@ module Text.PrettyPrint.Annotated.Leijen {-# DEPRECATED "Compatibility module fo
 
 ) where
 
-#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
-#else
-import Prelude
+
+#if !(LIFTA2_IN_PRELUDE)
+import Control.Applicative (liftA2)
 #endif
 
-#if !(MONOID_IN_PRELUDE)
-import Data.Monoid hiding ((<>))
-#endif
-
-import           Control.Applicative hiding (empty, (<$>))
 import qualified Data.Text           as T
 import qualified Data.Text.IO        as T
 import           System.IO

--- a/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
+++ b/prettyprinter-compat-ansi-wl-pprint/prettyprinter-compat-ansi-wl-pprint.cabal
@@ -33,6 +33,3 @@ library
         , text                        >= 1.2
         , prettyprinter               >= 1.7.0
         , prettyprinter-ansi-terminal >= 1.1
-
-    if !impl(ghc >= 8.0) && !impl(mhs)
-        build-depends: semigroups >= 0.1

--- a/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/prettyprinter-compat-ansi-wl-pprint/src/Text/PrettyPrint/ANSI/Leijen.hs
@@ -19,11 +19,7 @@ module Text.PrettyPrint.ANSI.Leijen {-# DEPRECATED "Compatibility module for use
 
 ) where
 
-#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
-#else
-import Prelude
-#endif
 
 import qualified Data.Text.Lazy as TL
 import           System.IO

--- a/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
+++ b/prettyprinter-compat-wl-pprint/prettyprinter-compat-wl-pprint.cabal
@@ -31,6 +31,3 @@ library
           base          >= 4.9 && < 5
         , text          >= 1.2
         , prettyprinter >= 1.7.0
-
-    if !impl(ghc >= 8.0) && !impl(mhs)
-        build-depends: semigroups >= 0.1

--- a/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
+++ b/prettyprinter-compat-wl-pprint/src/Text/PrettyPrint/Leijen.hs
@@ -16,11 +16,7 @@ module Text.PrettyPrint.Leijen {-# DEPRECATED "Compatibility module for users of
 
 
 
-#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
-#else
-import Prelude
-#endif
 
 import qualified Data.Text.Lazy as TL
 import           System.IO

--- a/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
+++ b/prettyprinter-convert-ansi-wl-pprint/prettyprinter-convert-ansi-wl-pprint.cabal
@@ -45,6 +45,3 @@ test-suite doctest
         , doctest >= 0.9
     ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
     default-language: Haskell2010
-    if impl (ghc < 7.10)
-        buildable: False
-        -- Doctest does not support searching through directories in old versions

--- a/prettyprinter/bench/Fusion.hs
+++ b/prettyprinter/bench/Fusion.hs
@@ -18,10 +18,6 @@ import           Prettyprinter
 import           Prettyprinter.Render.Text
 import qualified Text.PrettyPrint.ANSI.Leijen as WL
 
-#if !(APPLICATIVE_MONAD)
-import Control.Applicative
-#endif
-
 
 
 main :: IO ()
@@ -47,6 +43,8 @@ benchOptimize = env randomShortWords benchmark_
     randomShortWords' :: Int -> State StdGen [Text]
     randomShortWords' n = replicateM n randomShortWord
 
+    -- Note: 'split' is deprecated in random >= 1.2 in favor of 'splitGen'.
+    -- We could use 'splitGen' when support for GHC < 9.0 is dropped.
     randomShortWord :: State StdGen Text
     randomShortWord = do
         g <- get

--- a/prettyprinter/prettyprinter.cabal
+++ b/prettyprinter/prettyprinter.cabal
@@ -55,7 +55,7 @@ library
         , Data.Text.Prettyprint.Doc.Symbols.Unicode
         , Data.Text.Prettyprint.Doc.Symbols.Ascii
 
-    ghc-options: -Wall -O2
+    ghc-options: -Wall -O2 -Wcompat
     hs-source-dirs: src
     include-dirs: misc
     default-language: Haskell2010
@@ -79,17 +79,6 @@ library
             , Data.Text.IO
             , Data.Text.Lazy
             , Data.Text.Lazy.Builder
-
-    if !impl(ghc >= 7.6) && !impl(mhs)
-        build-depends: ghc-prim
-
-    if impl(ghc >= 8.0)
-        ghc-options: -Wcompat
-    if !impl(ghc >= 8.0) && !impl(mhs)
-        build-depends: semigroups >= 0.17
-        build-depends: fail >= 4.9.0.0 && <4.10
-    if !impl(ghc >= 7.10) && !impl(mhs)
-        build-depends: void >=0.4 && <0.8
 
 
 Flag buildReadme
@@ -139,9 +128,6 @@ test-suite doctest
         , QuickCheck >= 2.5
     ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
     default-language: Haskell2010
-    if impl (ghc < 7.10)
-        buildable: False
-        -- Doctest does not support searching through directories in old versions
 
 test-suite testsuite
     type: exitcode-stdio-1.0
@@ -161,9 +147,6 @@ test-suite testsuite
         , text
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
     default-language: Haskell2010
-
-    if !impl(ghc >= 8.0)
-        build-depends: semigroups >= 0.6
 
     if !flag(text)
         buildable: False

--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -101,9 +101,7 @@ import           GHC.Generics        (Generic)
 -- from the semigroups package.
 import Data.Semigroup
 
-#if NATURAL_IN_BASE
 import Numeric.Natural
-#endif
 
 #if !(FOLDABLE_TRAVERSABLE_IN_PRELUDE)
 import Data.Foldable    (Foldable (..))
@@ -111,9 +109,7 @@ import Data.Traversable (Traversable (..))
 import Prelude          hiding (null, foldr, foldr1)
 #endif
 
-#if FUNCTOR_IDENTITY_IN_BASE
 import Data.Functor.Identity
-#endif
 
 import Prettyprinter.Render.Util.Panic
 
@@ -300,12 +296,10 @@ instance ann ~ Void => Pretty (Doc ann) where
 instance Pretty a => Pretty (Const a b) where
   pretty = pretty . getConst
 
-#if FUNCTOR_IDENTITY_IN_BASE
 -- | >>> pretty (Identity 1)
 -- 1
 instance Pretty a => Pretty (Identity a) where
   pretty = pretty . runIdentity
-#endif
 
 -- | >>> pretty [1,2,3]
 -- [1, 2, 3]
@@ -368,10 +362,8 @@ instance PrettyAnn ann (Doc ann) where
 instance PrettyAnn ann a => PrettyAnn ann (Const a b) where
     prettyAnn = prettyAnn . getConst
 
-#if FUNCTOR_IDENTITY_IN_BASE
 instance PrettyAnn ann a => PrettyAnn ann (Identity a) where
     prettyAnn = prettyAnn . runIdentity
-#endif
 
 instance PrettyAnn ann a => PrettyAnn ann [a] where
     prettyAnn = prettyAnnList
@@ -415,9 +407,7 @@ instance Pretty Word64 where pretty = unsafeViaShow
 -- 10633823966279326983230456482242756608
 instance Pretty Integer where pretty = unsafeViaShow
 
-#if NATURAL_IN_BASE
 instance Pretty Natural where pretty = unsafeViaShow
-#endif
 
 -- | >>> pretty (pi :: Float)
 -- 3.1415927
@@ -519,9 +509,7 @@ instance PrettyAnn ann Word64 where prettyAnn = pretty
 
 instance PrettyAnn ann Integer where prettyAnn = pretty
 
-#if NATURAL_IN_BASE
 instance PrettyAnn ann Natural where prettyAnn = pretty
-#endif
 
 instance PrettyAnn ann Float where prettyAnn = pretty
 

--- a/prettyprinter/src/Prettyprinter/Render/Text.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Text.hs
@@ -28,14 +28,6 @@ import Prettyprinter
 import Prettyprinter.Internal
 import Prettyprinter.Render.Util.Panic
 
-#if !(SEMIGROUP_IN_BASE)
-import Data.Semigroup
-#endif
-
-#if !(APPLICATIVE_MONAD)
-import Control.Applicative
-#endif
-
 -- $setup
 --
 -- (Definitions for the doctests)

--- a/prettyprinter/src/Prettyprinter/Render/Tutorials/StackMachineTutorial.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Tutorials/StackMachineTutorial.hs
@@ -28,10 +28,6 @@ import Prettyprinter.Internal
 import Prettyprinter.Render.Util.Panic
 import Prettyprinter.Render.Util.StackMachine
 
-#if !(APPLICATIVE_MONAD)
-import Control.Applicative
-#endif
-
 -- * The type of available markup
 --
 -- $standalone-text

--- a/prettyprinter/src/Prettyprinter/Render/Util/SimpleDocTree.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Util/SimpleDocTree.hs
@@ -34,10 +34,6 @@ import Prettyprinter.Render.Util.Panic
 
 import qualified Control.Monad.Fail as Fail
 
-#if !(MONOID_IN_PRELUDE)
-import Data.Monoid (Monoid (..))
-#endif
-
 #if !(FOLDABLE_TRAVERSABLE_IN_PRELUDE)
 import Data.Foldable    (Foldable (..))
 import Data.Traversable (Traversable (..))
@@ -120,9 +116,6 @@ instance Monad (UniqueParser s) where
         let UniqueParser p' = f a'
         p' s' )
 
-#if !(APPLICATIVE_MONAD)
-    return = pure
-#endif
 #if FAIL_IN_MONAD
     fail = Fail.fail
 #endif

--- a/prettyprinter/src/Prettyprinter/Render/Util/StackMachine.hs
+++ b/prettyprinter/src/Prettyprinter/Render/Util/StackMachine.hs
@@ -31,7 +31,6 @@ module Prettyprinter.Render.Util.StackMachine (
 
 
 
-import           Control.Applicative
 import           Data.Text           (Text)
 import qualified Data.Text           as T
 
@@ -40,6 +39,10 @@ import Prettyprinter.Render.Util.Panic
 
 #if !(SEMIGROUP_MONOID_SUPERCLASS)
 import Data.Monoid
+#endif
+
+#if !(LIFTA2_IN_PRELUDE)
+import Control.Applicative (liftA2)
 #endif
 
 
@@ -129,9 +132,6 @@ instance Monoid output => Applicative (StackMachine output style) where
         in (f1 x2, w12, s2))
 
 instance Monoid output => Monad (StackMachine output style) where
-#if !(APPLICATIVE_MONAD)
-    return = pure
-#endif
     StackMachine r >>= f = StackMachine (\s ->
         let (x1, w1, s1) = r s
             StackMachine r1 = f x1

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -27,13 +27,6 @@ import Test.Tasty.QuickCheck
 
 import StripTrailingSpace
 
-#if !(APPLICATIVE_MONAD)
-import Control.Applicative
-#endif
-#if !(MONOID_IN_PRELUDE)
-import Data.Monoid (mconcat)
-#endif
-
 
 
 main :: IO ()

--- a/prettyprinter/test/Testsuite/StripTrailingSpace.hs
+++ b/prettyprinter/test/Testsuite/StripTrailingSpace.hs
@@ -16,10 +16,6 @@ import Prettyprinter.Render.Util.StackMachine
 import Test.Tasty
 import Test.Tasty.HUnit
 
-#if !(APPLICATIVE_MONAD)
-import Control.Applicative
-#endif
-
 
 
 box :: Text -> Text


### PR DESCRIPTION
    Follow-up to 92cc704 (drop GHC 7 support). Remove code that was only
    needed for GHC versions older than 8:
    
    - Remove CPP macros always true with base >= 4.9:
      APPLICATIVE_MONAD, FUNCTOR_IDENTITY_IN_BASE, MONOID_IN_PRELUDE,
      NATURAL_IN_BASE, SEMIGROUP_IN_BASE
    
    - Remove conditional dependencies on semigroups, fail, void, ghc-prim
    
    - Always enable -Wcompat (was conditional on GHC >= 8.0)
    
    - Remove doctest buildability conditions for GHC < 7.10
    
    - Remove unused Control.Applicative imports (in Prelude since base 4.8)
    
    Assisted-by: GLM-5 <noreply@fireworks.ai>
