### PR TITLE
Move the tests for `spaces` into the main testsuite

### DIFF
--- a/prettyprinter/src/Prettyprinter/Internal.hs
+++ b/prettyprinter/src/Prettyprinter/Internal.hs
@@ -80,7 +80,7 @@ module Prettyprinter.Internal (
     renderShowS,
 
     -- * Internal helpers
-    textSpaces
+    spaces, textSpaces
 ) where
 
 
@@ -1385,19 +1385,6 @@ spaces n
   | n == 1    = Char ' '
   | otherwise = Text n (textSpaces n)
 
--- $
--- prop> \(NonNegative n) -> length (show (spaces n)) == n
---
--- >>> case spaces 1 of Char ' ' -> True; _ -> False
--- True
---
--- >>> case spaces 0 of Empty -> True; _ -> False
--- True
---
--- prop> \(Positive n) -> case (spaces (-n)) of Empty -> True; _ -> False
-
-
-
 -- | @('plural' n one many)@ is @one@ if @n@ is @1@, and @many@ otherwise. A
 -- typical use case is  adding a plural "s".
 --
@@ -2348,4 +2335,3 @@ textSpaces n = T.replicate n (T.singleton ' ')
 -- >>> import Prettyprinter.Render.Text
 -- >>> import Prettyprinter.Symbols.Ascii
 -- >>> import Prettyprinter.Util as Util
--- >>> import Test.QuickCheck.Modifiers

--- a/prettyprinter/test/Testsuite/Main.hs
+++ b/prettyprinter/test/Testsuite/Main.hs
@@ -16,6 +16,7 @@ import           Data.Word
 import           System.Timeout        (timeout)
 
 import           Prettyprinter
+import qualified Prettyprinter.Internal as Internal
 import           Prettyprinter.Internal.Debug
 import           Prettyprinter.Render.Text
 import           Prettyprinter.Render.Util.StackMachine (renderSimplyDecorated)
@@ -41,6 +42,7 @@ tests = testGroup "Tests"
                        (fusionDoesNotChangeRendering Deep)
         ]
     , testStripTrailingSpace
+    , testSpaces
     , testGroup "Performance tests"
         [ testCase "Grouping performance"
                    groupingPerformance
@@ -86,6 +88,24 @@ tests = testGroup "Tests"
         , testCase "Ribbon width should be computed with `floor` instead of `round` (#157)"
                    computeRibbonWidthWithFloor
         ]
+    ]
+
+testSpaces :: TestTree
+testSpaces = testGroup "Spaces"
+    [ testProperty "n >= 0 ==> length (show (spaces n)) == n"
+        (\(NonNegative n) -> length (show (Internal.spaces n)) == n)
+    , testCase "spaces 1 is a Char ' '"
+        (case Internal.spaces 1 of
+            Internal.Char ' ' -> pure ()
+            _ -> assertFailure "Expected Char ' '")
+    , testCase "spaces 0 is Empty"
+        (case Internal.spaces 0 of
+            Internal.Empty -> pure ()
+            _ -> assertFailure "Expected Empty")
+    , testProperty "negative spaces are Empty"
+        (\(Positive n) -> case Internal.spaces (-n) of
+            Internal.Empty -> True
+            _ -> False)
     ]
 
 fusionDoesNotChangeRendering :: FusionDepth -> Property


### PR DESCRIPTION
This allows us to remove the problematic import of Test.QuickCheck.Modifiers from the doctests. (#290)