### PR TITLE
Make pp-ansi-terminal:doctest testsuite CI-only

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20260104
+# version: 0.19.20260331
 #
-# REGENDATA ("0.19.20260104",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20260331",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,6 +23,8 @@ on:
   merge_group:
     branches:
       - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -310,6 +312,16 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set prettyprinter-ansi-terminal-doctest
+        run: |
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='prettyprinter-ansi-terminal +doctest' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='prettyprinter-ansi-terminal +doctest' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='prettyprinter-ansi-terminal +doctest' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='prettyprinter-ansi-terminal +doctest' all
       - name: save cache
         if: always()
         uses: actions/cache/save@v5

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -5,3 +5,8 @@
 branches: master
 
 cabal-check: False
+
+constraint-set prettyprinter-ansi-terminal-doctest
+  constraints: prettyprinter-ansi-terminal +doctest
+  tests:       True
+  run-tests:   True

--- a/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
+++ b/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal.cabal
@@ -29,6 +29,11 @@ flag text
   default:     True
   manual:      True
 
+flag doctest
+  description: Enable the doctest test suite.
+  default:     False
+  manual:      True
+
 library
     exposed-modules:  Data.Text.Prettyprint.Doc.Render.Terminal
                     , Data.Text.Prettyprint.Doc.Render.Terminal.Internal
@@ -59,6 +64,11 @@ library
             , Data.Text.Lazy.Builder
 
 test-suite doctest
+    -- This test suite requires several imports that doctest can't resolve
+    -- unless it is given access to a GHC package environment.
+    -- Therefore it is disabled by default, while still being checked in CI.
+    if !flag(doctest)
+        buildable: False
     type: exitcode-stdio-1.0
     hs-source-dirs: test/Doctest
     main-is: Main.hs


### PR DESCRIPTION
The imports in these tests make them quite tricky to run via `cabal test`. Because this testsuite is quite small, we disable it for `cabal test` while ensuring that it is run in CI.

Closes #290.